### PR TITLE
Fix: Handle trailing slash in server URL to avoid double-slash in exchange endpoint

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -259,7 +259,8 @@ func obtainIDToken(ctx context.Context) (string, error) {
 
 // exchangeTokenForCert sends the ID token to the cert exchange server and returns the certificate response.
 func exchangeTokenForCert(ctx context.Context, client *http.Client, serverURL, idToken string) (*server.CertResponse, error) {
-	exchangeURL := serverURL + "/exchange"
+	// Trim trailing slash to avoid double-slash in URL construction
+	exchangeURL := strings.TrimRight(serverURL, "/") + "/exchange"
 
 	reqBody, err := json.Marshal(map[string]string{
 		"id_token": idToken,


### PR DESCRIPTION
## Summary

Fixes #54

When the `--server` flag includes a trailing slash (e.g., `https://localhost:8443/`), the login command constructs an invalid URL like `https://localhost:8443//exchange`, causing authentication to fail with a confusing 404 error.

## Changes

- Modified `exchangeTokenForCert()` in `cmd/login.go` to use `strings.TrimRight(serverURL, "/")` before constructing the exchange URL
- Added explanatory comment

## Testing

This fix ensures that:
- `https://localhost:8443` + `/exchange` → `https://localhost:8443/exchange` ✓
- `https://localhost:8443/` + `/exchange` → `https://localhost:8443/exchange` ✓

## Impact

- **Low risk**: Simple defensive fix, no behavior change for correctly formatted URLs
- **Fixes confusing UX**: Users will no longer get mysterious 404 errors when their server URL has a trailing slash

This is a good first issue fix as suggested in #54 🎉