### PR TITLE
New 'version' arg

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+// SetBuildInfo sets the build metadata (called from main with ldflags values).
+func SetBuildInfo(v, c, d string) {
+	if v != "" {
+		version = v
+	}
+	if c != "" {
+		commit = c
+	}
+	if d != "" {
+		date = d
+	}
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of talosctl-oidc",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("talosctl-oidc %s\n", version)
+		fmt.Printf("  commit: %s\n", commit)
+		fmt.Printf("  built:  %s\n", date)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,15 @@ import (
 	"github.com/qjoly/talosctl-oidc/cmd"
 )
 
+// version, commit and date are set at build time via -ldflags.
+var (
+	version string
+	commit  string
+	date    string
+)
+
 func main() {
+	cmd.SetBuildInfo(version, commit, date)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This pull request introduces a new `version` command to the CLI, allowing users to view the build version, commit hash, and build date. It also sets up infrastructure for injecting build metadata at compile time via `-ldflags`.

**New version command and build metadata injection:**

* Added a new `version` command in `cmd/version.go` that prints the version, commit, and build date of the CLI, and registers it with the root command.
* Updated `main.go` to define `version`, `commit`, and `date` variables set at build time, and to pass these values to the CLI via the new `SetBuildInfo` function.