### PR TITLE
Add rate limiting and IP allowlist features to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ listen: ":8443"
 cert_ttl: "1h"
 roles:
   - os:admin
+
+# Optional: Rate limiting (disabled by default)
+rate_limit_requests: 10
+rate_limit_window: "1m"
+
+# Optional: IP allowlist (empty = allow all)
+ip_allowlist:
+  - 192.168.1.0/24
+  - 10.0.0.50
 ```
 
 You can also set the config file path via the `TALOSCTL_OIDC_CONFIG` environment variable:
@@ -299,6 +308,9 @@ The server can be configured via **YAML configuration file** or **environment va
 | `TALOSCTL_OIDC_DATA_DIR` | `data_dir` | No | | Directory to persist self-signed TLS certs across restarts |
 | `TALOSCTL_OIDC_AUDIT_LOG` | `audit_log` | No | stdout | Path to audit log file (`-` for stdout) |
 | `TALOSCTL_OIDC_ADMIN_TOKEN` | `admin_token` | No | | Bearer token to protect `/admin/*` endpoints (required to enable admin API) |
+| `TALOSCTL_OIDC_RATE_LIMIT_REQUESTS` | `rate_limit_requests` | No | `0` | Max requests per IP per window (0 = disabled) |
+| `TALOSCTL_OIDC_RATE_LIMIT_WINDOW` | `rate_limit_window` | No | `1m` | Rate limit time window (e.g., `1m`, `5m`, `1h`) |
+| `TALOSCTL_OIDC_IP_ALLOWLIST` | `ip_allowlist` | No | | Comma-separated list of allowed IPs/CIDRs (empty = allow all) |
 | `DEBUG` | — | No | | Set to any value to enable detailed debug logging |
 
 \* *Either CA files, inline CA data, or talos_config is required*
@@ -1009,6 +1021,67 @@ curl -s -H "Authorization: Bearer $TALOSCTL_OIDC_ADMIN_TOKEN" \
 
 Expired certificates are automatically pruned from the list on each request.
 
+## Rate Limiting and IP Allowlist
+
+The server supports optional rate limiting and IP allowlisting on the `/exchange` endpoint to protect against abuse and brute-force attacks.
+
+### Rate Limiting
+
+Rate limiting is **disabled by default**. When enabled, it applies a per-IP sliding window limit to the `/exchange` endpoint.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `rate_limit_requests` | Maximum requests allowed per IP per window | `0` (disabled) |
+| `rate_limit_window` | Time window for counting requests | `1m` |
+
+**Configuration via environment variables:**
+```bash
+export TALOSCTL_OIDC_RATE_LIMIT_REQUESTS=10
+export TALOSCTL_OIDC_RATE_LIMIT_WINDOW=1m
+```
+
+**Configuration via config file:**
+```yaml
+rate_limit_requests: 10
+rate_limit_window: "1m"
+```
+
+**Example:** Allow 10 requests per minute per IP. Additional requests receive `429 Too Many Requests` with a `Retry-After` header.
+
+### IP Allowlist
+
+IP allowlisting restricts access to the `/exchange` endpoint to specific IP addresses or CIDR ranges.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ip_allowlist` | List of allowed IPs or CIDR ranges | (empty = allow all) |
+
+**Configuration via environment variables:**
+```bash
+export TALOSCTL_OIDC_IP_ALLOWLIST="192.168.1.0/24,10.0.0.50,172.16.0.0/16"
+```
+
+**Configuration via config file:**
+```yaml
+ip_allowlist:
+  - 192.168.1.0/24
+  - 10.0.0.50
+  - 172.16.0.0/16
+```
+
+**Note:** The server respects the `X-Forwarded-For` header for determining client IP when running behind a reverse proxy. Requests from IPs not in the allowlist receive `403 Forbidden`.
+
+### Helm Chart Configuration
+
+```yaml
+config:
+  rateLimitRequests: 10
+  rateLimitWindow: "1m"
+  ipAllowlist:
+    - 192.168.1.0/24
+    - 10.0.0.50
+```
+
 ## Security Considerations
 
 - **TLS by default**: The server generates a self-signed TLS certificate at startup when no TLS configuration is provided. Plain HTTP requires explicitly setting `TALOSCTL_OIDC_INSECURE=true`
@@ -1021,6 +1094,8 @@ Expired certificates are automatically pruned from the list on each request.
 - **State parameter** is used for CSRF protection during the OIDC flow
 - **Admin API is opt-in**: The `/admin/*` endpoints are disabled by default and require setting `TALOSCTL_OIDC_ADMIN_TOKEN`. The token is compared using constant-time comparison to prevent timing attacks
 - **Audit logging** provides a tamper-evident record of all authentication events for compliance and security monitoring
+- **Rate limiting** can be configured to prevent brute-force attacks on the `/exchange` endpoint (disabled by default)
+- **IP allowlisting** can restrict access to specific networks or IP addresses (disabled by default)
 
 ## Debugging
 

--- a/charts/talosctl-oidc/templates/deployment.yaml
+++ b/charts/talosctl-oidc/templates/deployment.yaml
@@ -109,6 +109,16 @@ spec:
               value: {{ .Values.config.auditLog | quote }}
             - name: TALOSCTL_OIDC_LISTEN
               value: ":8443"
+            {{- if .Values.config.rateLimitRequests }}
+            - name: TALOSCTL_OIDC_RATE_LIMIT_REQUESTS
+              value: {{ .Values.config.rateLimitRequests | quote }}
+            - name: TALOSCTL_OIDC_RATE_LIMIT_WINDOW
+              value: {{ .Values.config.rateLimitWindow | quote }}
+            {{- end }}
+            {{- if .Values.config.ipAllowlist }}
+            - name: TALOSCTL_OIDC_IP_ALLOWLIST
+              value: {{ join "," .Values.config.ipAllowlist | quote }}
+            {{- end }}
           volumeMounts:
             {{- if not (and .Values.talos.caCertData .Values.talos.caKeyData) }}
             - name: talos-ca

--- a/charts/talosctl-oidc/values.yaml
+++ b/charts/talosctl-oidc/values.yaml
@@ -143,6 +143,20 @@ config:
   # TALOSCTL_OIDC_AUDIT_LOG
   auditLog: "-"
 
+  # Rate limiting configuration
+  # TALOSCTL_OIDC_RATE_LIMIT_REQUESTS: requests per window (0 = disabled)
+  # TALOSCTL_OIDC_RATE_LIMIT_WINDOW: rate limit window duration (e.g., "1m", "5m", "1h")
+  rateLimitRequests: 0
+  rateLimitWindow: "1m"
+
+  # IP allowlist configuration
+  # TALOSCTL_OIDC_IP_ALLOWLIST: comma-separated list of allowed IPs/CIDRs
+  # Example:
+  #   ipAllowlist:
+  #     - 192.168.1.0/24
+  #     - 10.0.0.50
+  ipAllowlist: []
+
 # Talos CA Configuration
 talos:
   # Name of an existing secret containing the Talos CA cert and key.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,9 +12,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/qjoly/talosctl-oidc/pkg/admin"
+	"github.com/qjoly/talosctl-oidc/pkg/allowlist"
 	"github.com/qjoly/talosctl-oidc/pkg/audit"
 	"github.com/qjoly/talosctl-oidc/pkg/certsign"
 	"github.com/qjoly/talosctl-oidc/pkg/config"
+	"github.com/qjoly/talosctl-oidc/pkg/ratelimit"
 	"github.com/qjoly/talosctl-oidc/pkg/server"
 )
 
@@ -54,6 +56,11 @@ Example configuration file:
   data_dir: /var/lib/talosctl-oidc
   audit_log: /var/log/talosctl-oidc/audit.log
   admin_token: my-secret-token
+  rate_limit_requests: 10
+  rate_limit_window: "1m"
+  ip_allowlist:
+    - 192.168.1.0/24
+    - 10.0.0.50
 
 Environment variables (override config file values):
 
@@ -82,6 +89,15 @@ Audit & admin:
 
   TALOSCTL_OIDC_AUDIT_LOG    Path to audit log file (default: stdout, "-" for stdout)
   TALOSCTL_OIDC_ADMIN_TOKEN  Bearer token for /admin/* endpoints
+
+Rate limiting:
+
+  TALOSCTL_OIDC_RATE_LIMIT_REQUESTS  Requests per window (default: 0 = disabled)
+  TALOSCTL_OIDC_RATE_LIMIT_WINDOW    Rate limit window (default: "1m")
+
+IP allowlist:
+
+  TALOSCTL_OIDC_IP_ALLOWLIST  Comma-separated list of allowed IPs/CIDRs (default: allow all)
 
 By default (no TLS config), the server generates a self-signed TLS
 certificate at startup and logs the CA PEM so clients can trust it via
@@ -178,6 +194,34 @@ func runServe(cmd *cobra.Command, args []string) error {
 		log.Printf("Admin API: disabled (set admin_token / TALOSCTL_OIDC_ADMIN_TOKEN to enable)")
 	}
 
+	// Initialize rate limiter if configured.
+	var rateLimiter *ratelimit.Limiter
+	if rc.RateLimitRequests > 0 {
+		window := rc.RateLimitWindow
+		if window <= 0 {
+			window = time.Minute
+		}
+		rateLimiter = ratelimit.New(rc.RateLimitRequests, window)
+		cleanupStop := rateLimiter.StartCleanup(5 * time.Minute)
+		defer close(cleanupStop)
+		log.Printf("Rate limiting: enabled (%d requests per %v)", rc.RateLimitRequests, window)
+	} else {
+		log.Printf("Rate limiting: disabled")
+	}
+
+	// Initialize IP allowlist if configured.
+	var ipAllowlist *allowlist.Allowlist
+	if len(rc.IPAllowlist) > 0 {
+		var err error
+		ipAllowlist, err = allowlist.New(rc.IPAllowlist)
+		if err != nil {
+			return fmt.Errorf("initializing IP allowlist: %w", err)
+		}
+		log.Printf("IP allowlist: enabled (%d entries)", len(rc.IPAllowlist))
+	} else {
+		log.Printf("IP allowlist: disabled")
+	}
+
 	cfg := server.Config{
 		ListenAddr:   rc.Listen,
 		CA:           ca,
@@ -194,6 +238,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		AuditLogger:  auditLogger,
 		AdminToken:   rc.AdminToken,
 		AdminTracker: tracker,
+		RateLimiter:  rateLimiter,
+		Allowlist:    ipAllowlist,
 	}
 
 	srv := server.New(cfg)

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -6,6 +6,14 @@ client_id: talosctl_oidc # Required
 ca_cert: temp/talos-ca.crt
 ca_key: temp/talos-api-ca.key
 
+rate_limit_requests: 10
+rate_limit_window: "1m"
+
+ip_allowlist:
+  - 192.168.1.0/24
+  - 10.0.0.50
+  - ::1
+
 # Network Configuration
 listen: ":8443"
 endpoints:

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -1,0 +1,139 @@
+// Package allowlist provides IP allowlisting functionality for the HTTP server.
+// It supports CIDR notation and individual IP addresses.
+package allowlist
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Allowlist manages a list of allowed IP addresses and CIDR ranges.
+type Allowlist struct {
+	nets []net.IPNet
+	ips  []net.IP
+}
+
+// New creates a new allowlist from a list of CIDR strings or IP addresses.
+// If the list is empty, the allowlist allows all IPs (IsEnabled returns false).
+func New(allowed []string) (*Allowlist, error) {
+	if len(allowed) == 0 {
+		return &Allowlist{}, nil
+	}
+
+	a := &Allowlist{}
+	for _, s := range allowed {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+
+		// Try to parse as CIDR first.
+		_, ipnet, err := net.ParseCIDR(s)
+		if err == nil {
+			a.nets = append(a.nets, *ipnet)
+			continue
+		}
+
+		// Try to parse as individual IP.
+		ip := net.ParseIP(s)
+		if ip != nil {
+			a.ips = append(a.ips, ip)
+			continue
+		}
+
+		return nil, &ParseError{Input: s, Err: err}
+	}
+
+	return a, nil
+}
+
+// ParseError represents an error parsing an allowlist entry.
+type ParseError struct {
+	Input string
+	Err   error
+}
+
+func (e *ParseError) Error() string {
+	return "invalid IP or CIDR: " + e.Input
+}
+
+func (e *ParseError) Unwrap() error {
+	return e.Err
+}
+
+// IsEnabled returns true if the allowlist has entries and will perform checks.
+func (a *Allowlist) IsEnabled() bool {
+	return a != nil && (len(a.nets) > 0 || len(a.ips) > 0)
+}
+
+// Allowed checks if the given IP address is in the allowlist.
+// If the allowlist is not enabled, it always returns true.
+func (a *Allowlist) Allowed(ip string) bool {
+	if !a.IsEnabled() {
+		return true
+	}
+
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false
+	}
+
+	// Check individual IPs.
+	for _, allowedIP := range a.ips {
+		if allowedIP.Equal(parsedIP) {
+			return true
+		}
+	}
+
+	// Check CIDR ranges.
+	for _, net := range a.nets {
+		if net.Contains(parsedIP) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// extractIP extracts the client IP from the request, handling X-Forwarded-For header.
+func extractIP(r *http.Request) string {
+	// Check X-Forwarded-For header first (for requests behind proxy).
+	forwarded := r.Header.Get("X-Forwarded-For")
+	if forwarded != "" {
+		// Take the first IP if multiple are present.
+		ips := strings.Split(forwarded, ",")
+		if len(ips) > 0 {
+			ip := strings.TrimSpace(ips[0])
+			return ip
+		}
+	}
+
+	// Fall back to RemoteAddr.
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// Middleware returns an HTTP middleware that checks IP allowlisting.
+// If the IP is not allowed, it returns 403 Forbidden.
+func (a *Allowlist) Middleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !a.IsEnabled() {
+			next(w, r)
+			return
+		}
+
+		ip := extractIP(r)
+		if !a.Allowed(ip) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error": "IP not allowed"}`))
+			return
+		}
+
+		next(w, r)
+	}
+}

--- a/pkg/allowlist/allowlist_test.go
+++ b/pkg/allowlist/allowlist_test.go
@@ -1,0 +1,148 @@
+package allowlist
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAllowlist_New(t *testing.T) {
+	// Test empty allowlist (allow all).
+	a, err := New([]string{})
+	if err != nil {
+		t.Errorf("New() with empty list should not error: %v", err)
+	}
+	if a.IsEnabled() {
+		t.Error("IsEnabled() should be false for empty allowlist")
+	}
+
+	// Test with valid IPs.
+	a, err = New([]string{"192.168.1.1", "10.0.0.0/8"})
+	if err != nil {
+		t.Errorf("New() with valid IPs should not error: %v", err)
+	}
+	if !a.IsEnabled() {
+		t.Error("IsEnabled() should be true for non-empty allowlist")
+	}
+
+	// Test with invalid input.
+	_, err = New([]string{"invalid-ip"})
+	if err == nil {
+		t.Error("New() should error with invalid IP")
+	}
+}
+
+func TestAllowlist_Allowed(t *testing.T) {
+	a, err := New([]string{"192.168.1.0/24", "10.0.0.50"})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	tests := []struct {
+		ip      string
+		allowed bool
+	}{
+		{"192.168.1.1", true},
+		{"192.168.1.100", true},
+		{"192.168.1.255", true},
+		{"10.0.0.50", true},
+		{"192.168.2.1", false},
+		{"10.0.0.51", false},
+		{"172.16.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			got := a.Allowed(tt.ip)
+			if got != tt.allowed {
+				t.Errorf("Allowed(%q) = %v, want %v", tt.ip, got, tt.allowed)
+			}
+		})
+	}
+}
+
+func TestAllowlist_AllowedEmpty(t *testing.T) {
+	// Empty allowlist should allow all.
+	a, _ := New([]string{})
+
+	tests := []string{"192.168.1.1", "10.0.0.1", "0.0.0.0", "255.255.255.255"}
+	for _, ip := range tests {
+		if !a.Allowed(ip) {
+			t.Errorf("Allowed(%q) should be true for empty allowlist", ip)
+		}
+	}
+}
+
+func TestAllowlist_Middleware(t *testing.T) {
+	a, _ := New([]string{"192.168.1.0/24"})
+
+	// Create a handler that returns 200.
+	handler := a.Middleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	// Test allowed IP.
+	t.Run("allowed IP", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = "192.168.1.100:12345"
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", rr.Code)
+		}
+	})
+
+	// Test denied IP.
+	t.Run("denied IP", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("Expected status 403, got %d", rr.Code)
+		}
+	})
+}
+
+func TestExtractIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		forwarded  string
+		want       string
+	}{
+		{
+			name:       "RemoteAddr only",
+			remoteAddr: "192.168.1.1:12345",
+			want:       "192.168.1.1",
+		},
+		{
+			name:       "X-Forwarded-For single",
+			remoteAddr: "10.0.0.1:12345",
+			forwarded:  "192.168.1.100",
+			want:       "192.168.1.100",
+		},
+		{
+			name:       "X-Forwarded-For multiple",
+			remoteAddr: "10.0.0.1:12345",
+			forwarded:  "192.168.1.100, 10.0.0.2, 10.0.0.3",
+			want:       "192.168.1.100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.forwarded != "" {
+				req.Header.Set("X-Forwarded-For", tt.forwarded)
+			}
+
+			got := extractIP(req)
+			if got != tt.want {
+				t.Errorf("extractIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,29 +54,39 @@ type FileConfig struct {
 	// Audit & admin configuration.
 	AuditLog   string `yaml:"audit_log"`   // Path to audit log file.
 	AdminToken string `yaml:"admin_token"` // Bearer token for /admin/* endpoints.
+
+	// Rate limiting configuration.
+	RateLimitRequests int           `yaml:"rate_limit_requests"` // Requests per window (default: 0 = disabled).
+	RateLimitWindow   time.Duration `yaml:"rate_limit_window"`   // Rate limit window (default: 1m).
+
+	// IP allowlist configuration.
+	IPAllowlist []string `yaml:"ip_allowlist"` // List of allowed CIDRs/IPs (empty = allow all).
 }
 
 // ResolvedConfig holds the final merged configuration values as strings,
 // ready for validation and conversion in the serve command.
 type ResolvedConfig struct {
-	CACert       string
-	CAKey        string
-	CACertData   string
-	CAKeyData    string
-	TalosConfig  string
-	IssuerURL    string
-	ClientID     string
-	ClientSecret string
-	Listen       string
-	Endpoints    []string
-	CertTTL      string
-	Roles        []string
-	TLSCert      string
-	TLSKey       string
-	Insecure     bool
-	DataDir      string
-	AuditLog     string
-	AdminToken   string
+	CACert            string
+	CAKey             string
+	CACertData        string
+	CAKeyData         string
+	TalosConfig       string
+	IssuerURL         string
+	ClientID          string
+	ClientSecret      string
+	Listen            string
+	Endpoints         []string
+	CertTTL           string
+	Roles             []string
+	TLSCert           string
+	TLSKey            string
+	Insecure          bool
+	DataDir           string
+	AuditLog          string
+	AdminToken        string
+	RateLimitRequests int
+	RateLimitWindow   time.Duration
+	IPAllowlist       []string
 }
 
 // LoadFile reads and parses a YAML configuration file.
@@ -153,6 +163,26 @@ func Load(configPath string) (*ResolvedConfig, error) {
 		rc.Insecure = strings.EqualFold(envInsecure, "true") || envInsecure == "1"
 	} else {
 		rc.Insecure = fileCfg.Insecure
+	}
+
+	// Rate limiting: env var > file.
+	rc.RateLimitRequests = fileCfg.RateLimitRequests
+	if envRateLimit := os.Getenv("TALOSCTL_OIDC_RATE_LIMIT_REQUESTS"); envRateLimit != "" {
+		fmt.Sscanf(envRateLimit, "%d", &rc.RateLimitRequests)
+	}
+
+	rc.RateLimitWindow = fileCfg.RateLimitWindow
+	if envWindow := os.Getenv("TALOSCTL_OIDC_RATE_LIMIT_WINDOW"); envWindow != "" {
+		if d, err := time.ParseDuration(envWindow); err == nil {
+			rc.RateLimitWindow = d
+		}
+	}
+
+	// IP allowlist: env var (comma-separated) > file.
+	if envAllowlist := os.Getenv("TALOSCTL_OIDC_IP_ALLOWLIST"); envAllowlist != "" {
+		rc.IPAllowlist = strings.Split(envAllowlist, ",")
+	} else if len(fileCfg.IPAllowlist) > 0 {
+		rc.IPAllowlist = fileCfg.IPAllowlist
 	}
 
 	return rc, nil

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -1,0 +1,184 @@
+// Package ratelimit provides rate limiting functionality for the HTTP server.
+// It implements a per-IP sliding window rate limiter with configurable
+// request limits and time windows.
+package ratelimit
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Limiter implements a sliding window rate limiter per IP address.
+type Limiter struct {
+	requests int           // Max requests allowed per window
+	window   time.Duration // Time window for rate limiting
+	clients  map[string]*client
+	mu       sync.RWMutex
+}
+
+// client tracks request timestamps for a single IP.
+type client struct {
+	timestamps []time.Time
+	mu         sync.Mutex
+}
+
+// New creates a new rate limiter with the specified request limit and window.
+// If requests is 0, rate limiting is disabled.
+func New(requests int, window time.Duration) *Limiter {
+	if window <= 0 {
+		window = time.Minute
+	}
+	return &Limiter{
+		requests: requests,
+		window:   window,
+		clients:  make(map[string]*client),
+	}
+}
+
+// IsEnabled returns true if rate limiting is enabled.
+func (l *Limiter) IsEnabled() bool {
+	return l != nil && l.requests > 0
+}
+
+// Allow checks if a request from the given IP is allowed.
+// It returns true if the request is within the rate limit.
+func (l *Limiter) Allow(ip string) bool {
+	if !l.IsEnabled() {
+		return true
+	}
+
+	// Clean up old timestamps outside the window.
+	now := time.Now()
+	cutoff := now.Add(-l.window)
+
+	l.mu.Lock()
+	c, exists := l.clients[ip]
+	if !exists {
+		c = &client{}
+		l.clients[ip] = c
+	}
+	l.mu.Unlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Remove timestamps outside the window.
+	valid := c.timestamps[:0]
+	for _, ts := range c.timestamps {
+		if ts.After(cutoff) {
+			valid = append(valid, ts)
+		}
+	}
+	c.timestamps = valid
+
+	// Check if we're over the limit.
+	if len(c.timestamps) >= l.requests {
+		return false
+	}
+
+	// Record this request.
+	c.timestamps = append(c.timestamps, now)
+	return true
+}
+
+// extractIP extracts the client IP from the request, handling X-Forwarded-For header.
+func extractIP(r *http.Request) string {
+	// Check X-Forwarded-For header first (for requests behind proxy).
+	forwarded := r.Header.Get("X-Forwarded-For")
+	if forwarded != "" {
+		// Take the first IP if multiple are present.
+		ips := strings.Split(forwarded, ",")
+		if len(ips) > 0 {
+			ip := strings.TrimSpace(ips[0])
+			return ip
+		}
+	}
+
+	// Fall back to RemoteAddr.
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// Middleware returns an HTTP middleware that applies rate limiting.
+// If the limit is exceeded, it returns 429 Too Many Requests.
+func (l *Limiter) Middleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !l.IsEnabled() {
+			next(w, r)
+			return
+		}
+
+		ip := extractIP(r)
+		if !l.Allow(ip) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", fmt.Sprintf("%d", int(l.window.Seconds())))
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error": "rate limit exceeded"}`))
+			return
+		}
+
+		next(w, r)
+	}
+}
+
+// Cleanup removes stale entries from the rate limiter to prevent memory leaks.
+// Should be called periodically (e.g., via a background goroutine).
+func (l *Limiter) Cleanup() {
+	if !l.IsEnabled() {
+		return
+	}
+
+	cutoff := time.Now().Add(-l.window)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for ip, c := range l.clients {
+		c.mu.Lock()
+		valid := c.timestamps[:0]
+		for _, ts := range c.timestamps {
+			if ts.After(cutoff) {
+				valid = append(valid, ts)
+			}
+		}
+		c.timestamps = valid
+		c.mu.Unlock()
+
+		// Remove client entry if no recent requests.
+		if len(c.timestamps) == 0 {
+			delete(l.clients, ip)
+		}
+	}
+}
+
+// StartCleanup starts a background goroutine that periodically cleans up
+// stale rate limiter entries. Call StopCleanup to stop it.
+func (l *Limiter) StartCleanup(interval time.Duration) chan struct{} {
+	stop := make(chan struct{})
+	if !l.IsEnabled() {
+		return stop
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				l.Cleanup()
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	return stop
+}

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -1,0 +1,163 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_Allow(t *testing.T) {
+	// Test disabled rate limiter (requests = 0).
+	l := New(0, time.Minute)
+	if l.IsEnabled() {
+		t.Error("IsEnabled() should return false when requests is 0 (disabled)")
+	}
+
+	// Test with limit of 2 requests per minute.
+	l = New(2, time.Minute)
+	if !l.IsEnabled() {
+		t.Error("IsEnabled() should return true with positive requests")
+	}
+
+	// First two requests should be allowed.
+	if !l.Allow("192.168.1.1") {
+		t.Error("First request should be allowed")
+	}
+	if !l.Allow("192.168.1.1") {
+		t.Error("Second request should be allowed")
+	}
+
+	// Third request should be denied.
+	if l.Allow("192.168.1.1") {
+		t.Error("Third request should be denied")
+	}
+
+	// Different IP should still be allowed.
+	if !l.Allow("192.168.1.2") {
+		t.Error("Request from different IP should be allowed")
+	}
+}
+
+func TestRateLimiter_Window(t *testing.T) {
+	// Test with a very short window.
+	l := New(1, 50*time.Millisecond)
+
+	// First request allowed.
+	if !l.Allow("192.168.1.1") {
+		t.Error("First request should be allowed")
+	}
+
+	// Second request denied.
+	if l.Allow("192.168.1.1") {
+		t.Error("Second request should be denied")
+	}
+
+	// Wait for window to pass.
+	time.Sleep(100 * time.Millisecond)
+
+	// Now request should be allowed again.
+	if !l.Allow("192.168.1.1") {
+		t.Error("Request after window should be allowed")
+	}
+}
+
+func TestRateLimiter_Middleware(t *testing.T) {
+	l := New(1, time.Minute)
+
+	// Create a simple handler that returns 200.
+	handler := l.Middleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	// First request should pass.
+	req1 := httptest.NewRequest("GET", "/", nil)
+	rr1 := httptest.NewRecorder()
+	handler(rr1, req1)
+	if rr1.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rr1.Code)
+	}
+
+	// Second request should be rate limited.
+	req2 := httptest.NewRequest("GET", "/", nil)
+	rr2 := httptest.NewRecorder()
+	handler(rr2, req2)
+	if rr2.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429, got %d", rr2.Code)
+	}
+
+	// Check Retry-After header.
+	if rr2.Header().Get("Retry-After") == "" {
+		t.Error("Expected Retry-After header")
+	}
+}
+
+func TestExtractIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		forwarded  string
+		want       string
+	}{
+		{
+			name:       "RemoteAddr only",
+			remoteAddr: "192.168.1.1:12345",
+			want:       "192.168.1.1",
+		},
+		{
+			name:       "X-Forwarded-For single",
+			remoteAddr: "10.0.0.1:12345",
+			forwarded:  "192.168.1.100",
+			want:       "192.168.1.100",
+		},
+		{
+			name:       "X-Forwarded-For multiple",
+			remoteAddr: "10.0.0.1:12345",
+			forwarded:  "192.168.1.100, 10.0.0.2, 10.0.0.3",
+			want:       "192.168.1.100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.forwarded != "" {
+				req.Header.Set("X-Forwarded-For", tt.forwarded)
+			}
+
+			got := extractIP(req)
+			if got != tt.want {
+				t.Errorf("extractIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimiter_Cleanup(t *testing.T) {
+	// Create limiter with short window.
+	l := New(10, 100*time.Millisecond)
+
+	// Add requests from multiple IPs.
+	l.Allow("192.168.1.1")
+	l.Allow("192.168.1.2")
+	l.Allow("192.168.1.3")
+
+	// Wait for window to expire.
+	time.Sleep(150 * time.Millisecond)
+
+	// Cleanup should remove old entries.
+	l.Cleanup()
+
+	// All IPs should be able to make requests again.
+	if !l.Allow("192.168.1.1") {
+		t.Error("Request from 192.168.1.1 should be allowed after cleanup")
+	}
+	if !l.Allow("192.168.1.2") {
+		t.Error("Request from 192.168.1.2 should be allowed after cleanup")
+	}
+	if !l.Allow("192.168.1.3") {
+		t.Error("Request from 192.168.1.3 should be allowed after cleanup")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,9 +24,11 @@ import (
 	"time"
 
 	"github.com/qjoly/talosctl-oidc/pkg/admin"
+	"github.com/qjoly/talosctl-oidc/pkg/allowlist"
 	"github.com/qjoly/talosctl-oidc/pkg/audit"
 	"github.com/qjoly/talosctl-oidc/pkg/certsign"
 	"github.com/qjoly/talosctl-oidc/pkg/oidc"
+	"github.com/qjoly/talosctl-oidc/pkg/ratelimit"
 )
 
 func debug(format string, v ...interface{}) {
@@ -90,6 +92,14 @@ type Config struct {
 	// AdminTracker is the in-memory tracker for issued certs and stats.
 	// When non-nil, the /admin/certs and /admin/stats endpoints are enabled.
 	AdminTracker *admin.Tracker
+
+	// RateLimiter is an optional rate limiter for the /exchange endpoint.
+	// When non-nil, requests are rate-limited per IP.
+	RateLimiter *ratelimit.Limiter
+
+	// Allowlist is an optional IP allowlist for the /exchange endpoint.
+	// When non-nil, only IPs in the allowlist can access the endpoint.
+	Allowlist *allowlist.Allowlist
 }
 
 // CertResponse is the JSON response returned to clients after successful token exchange.
@@ -121,7 +131,17 @@ func New(cfg Config) *Server {
 	s := &Server{cfg: cfg}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/exchange", s.handleExchange)
+
+	// Apply rate limiting and IP allowlist middleware to /exchange endpoint.
+	exchangeHandler := http.HandlerFunc(s.handleExchange)
+	if cfg.Allowlist != nil && cfg.Allowlist.IsEnabled() {
+		exchangeHandler = cfg.Allowlist.Middleware(exchangeHandler)
+	}
+	if cfg.RateLimiter != nil && cfg.RateLimiter.IsEnabled() {
+		exchangeHandler = cfg.RateLimiter.Middleware(exchangeHandler)
+	}
+	mux.HandleFunc("/exchange", exchangeHandler)
+
 	mux.HandleFunc("/healthz", s.handleHealth)
 	mux.HandleFunc("/ca", s.handleCA)
 


### PR DESCRIPTION
- Introduced configuration options for rate limiting and IP allowlisting in the YAML config and environment variables.
- Implemented rate limiting logic in the server to protect the /exchange endpoint from abuse.
- Added middleware for IP allowlisting to restrict access based on specified IPs or CIDR ranges.
- Updated documentation to reflect new configuration options and usage examples.

Closes #12
