### PR TITLE
Fix: add nil-tracker guard in admin API handlers (LOW-10)

### DIFF
--- a/pkg/server/admin_dashboard.go
+++ b/pkg/server/admin_dashboard.go
@@ -266,7 +266,10 @@ func (s *Server) handleAdminDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isLoggedIn {
-		// Get stats and certs from tracker
+		if s.cfg.AdminTracker == nil {
+			writeError(w, http.StatusInternalServerError, "tracker not initialized")
+			return
+		}
 		data.Stats = s.cfg.AdminTracker.GetStats()
 		data.Certs = s.cfg.AdminTracker.ActiveCerts()
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -710,6 +710,11 @@ func (s *Server) handleAdminStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.cfg.AdminTracker == nil {
+		writeError(w, http.StatusInternalServerError, "tracker not initialized")
+		return
+	}
+
 	stats := s.cfg.AdminTracker.GetStats()
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(stats)
@@ -722,6 +727,11 @@ func (s *Server) handleAdminStats(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleAdminCerts(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	if s.cfg.AdminTracker == nil {
+		writeError(w, http.StatusInternalServerError, "tracker not initialized")
 		return
 	}
 


### PR DESCRIPTION
## Summary

Adds nil checks for `AdminTracker` in admin API handlers to prevent nil pointer dereference when tracker is not initialized.

## Changes

- Add nil-tracker check in `handleAdminDashboard`
- Add nil-tracker check in `handleAdminStats`
- Add nil-tracker check in `handleAdminCerts`

Returns HTTP 500 "tracker not initialized" instead of panicking.

Closes #55