### PR TITLE
Fix: use standard PEM type for PKCS8 private keys (LOW-2)

### DIFF
--- a/pkg/certsign/certsign.go
+++ b/pkg/certsign/certsign.go
@@ -194,7 +194,7 @@ func GenerateClientCert(ca *CA, roles []string, ttl time.Duration) (*ClientCerti
 	}
 
 	keyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "ED25519 PRIVATE KEY",
+		Type:  "PRIVATE KEY",
 		Bytes: privKeyBytes,
 	})
 


### PR DESCRIPTION
## Summary

Ed25519 private keys encoded in PKCS8 format now use the standard PEM type "PRIVATE KEY" instead of the non-standard "ED25519 PRIVATE KEY". This improves interoperability with OpenSSL, kubectl, and other tools.

Closes #47