### PR TITLE
fix: add server-side algorithm allowlist to prevent JWT algorithm confusion

### DIFF
--- a/pkg/oidc/jwt.go
+++ b/pkg/oidc/jwt.go
@@ -77,7 +77,10 @@ func FetchJWKS(ctx context.Context, jwksURI string) (*JWKS, error) {
 // ValidateIDToken validates a JWT ID token against the given JWKS, issuer, and audience.
 // For HS256/HS384/HS512 tokens, the clientSecret is used as the HMAC key.
 // For asymmetric algorithms (RS256, ES256, EdDSA, etc.), the JWKS is used.
+// allowedAlgs is the server-side allowlist of permitted JWT algorithms (e.g. ["RS256", "ES256"]).
+// If empty, defaults to ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "EdDSA"].
 // It verifies:
+//   - The token algorithm is in the server-side allowlist
 //   - The token signature
 //   - The issuer (iss) matches the expected issuer
 //   - The audience (aud) contains the expected client ID
@@ -85,7 +88,7 @@ func FetchJWKS(ctx context.Context, jwksURI string) (*JWKS, error) {
 //   - The token is not used before its "not before" time (nbf), if present
 //
 // Returns the token claims on success.
-func ValidateIDToken(rawToken string, jwks *JWKS, expectedIssuer, expectedAudience, clientSecret string) (map[string]interface{}, error) {
+func ValidateIDToken(rawToken string, jwks *JWKS, expectedIssuer, expectedAudience, clientSecret string, allowedAlgs []string) (map[string]interface{}, error) {
 	parts := strings.Split(rawToken, ".")
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("invalid JWT: expected 3 parts, got %d", len(parts))
@@ -104,6 +107,26 @@ func ValidateIDToken(rawToken string, jwks *JWKS, expectedIssuer, expectedAudien
 	}
 	if err := json.Unmarshal(headerJSON, &header); err != nil {
 		return nil, fmt.Errorf("parsing JWT header: %w", err)
+	}
+
+	// Explicitly reject 'none' algorithm before allowlist check.
+	if header.Alg == "" || header.Alg == "none" {
+		return nil, fmt.Errorf("JWT algorithm %q is not permitted", header.Alg)
+	}
+
+	// Validate algorithm against server-side allowlist.
+	if len(allowedAlgs) == 0 {
+		allowedAlgs = []string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "EdDSA"}
+	}
+	algAllowed := false
+	for _, a := range allowedAlgs {
+		if a == header.Alg {
+			algAllowed = true
+			break
+		}
+	}
+	if !algAllowed {
+		return nil, fmt.Errorf("JWT algorithm %q is not in the server-side allowlist", header.Alg)
 	}
 
 	// Verify signature.

--- a/pkg/oidc/jwt_test.go
+++ b/pkg/oidc/jwt_test.go
@@ -73,7 +73,7 @@ func TestValidateIDToken_Expired(t *testing.T) {
 		mac.Write([]byte(input))
 		return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 	})
-	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret)
+	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret, []string{"HS256"})
 	if err == nil {
 		t.Error("expected error for expired token")
 	}
@@ -94,7 +94,7 @@ func TestValidateIDToken_ValidHS256(t *testing.T) {
 		mac.Write([]byte(input))
 		return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 	})
-	result, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret)
+	result, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret, []string{"HS256"})
 	if err != nil {
 		t.Fatalf("expected no error for valid token, got %v", err)
 	}
@@ -120,7 +120,7 @@ func TestValidateIDToken_IssuerTrailingSlash(t *testing.T) {
 		return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 	})
 	// Expected issuer without trailing slash — should still match
-	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret)
+	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret, []string{"HS256"})
 	if err != nil {
 		t.Errorf("expected issuer trailing slash to be normalized, got error: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestValidateIDToken_IssuerMismatch(t *testing.T) {
 		mac.Write([]byte(input))
 		return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 	})
-	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret)
+	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret, []string{"HS256"})
 	if err == nil {
 		t.Error("expected error for issuer mismatch")
 	}
@@ -162,7 +162,7 @@ func TestValidateIDToken_AudienceMismatch(t *testing.T) {
 		mac.Write([]byte(input))
 		return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 	})
-	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret)
+	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret, []string{"HS256"})
 	if err == nil {
 		t.Error("expected error for audience mismatch")
 	}
@@ -183,7 +183,7 @@ func TestValidateIDToken_InvalidSignature(t *testing.T) {
 		return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 	})
 	// Validate with wrong secret
-	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", "wrong-secret")
+	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", "wrong-secret", []string{"HS256"})
 	if err == nil {
 		t.Error("expected error for invalid signature")
 	}
@@ -203,7 +203,7 @@ func TestValidateIDToken_MissingExpClaim(t *testing.T) {
 		mac.Write([]byte(input))
 		return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 	})
-	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret)
+	_, err := ValidateIDToken(token, nil, "https://issuer.example.com", "client-id", secret, []string{"HS256"})
 	if err == nil {
 		t.Error("expected error for token missing exp claim")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -706,7 +706,7 @@ func (s *Server) validateToken(ctx context.Context, idToken string) (*tokenClaim
 
 	// Parse and validate the token.
 	debug("Verifying ID token signature and claims (ClientID: %s)...", s.cfg.ClientID)
-	claims, err := oidc.ValidateIDToken(idToken, jwks, s.cfg.IssuerURL, s.cfg.ClientID, s.cfg.ClientSecret)
+	claims, err := oidc.ValidateIDToken(idToken, jwks, s.cfg.IssuerURL, s.cfg.ClientID, s.cfg.ClientSecret, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Add `allowedAlgs []string` parameter to `ValidateIDToken` to enforce an explicit algorithm allowlist
- Explicitly reject `""` and `"none"` algorithms before any other checks
- Default allowlist: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `EdDSA`
- Prevents algorithm confusion/substitution attacks where an attacker downgrades to HMAC or `none`

## Fixes
Closes #24

## Test plan
- [ ] Verify tokens with allowed algorithms still validate
- [ ] Verify tokens with `alg: "none"` are rejected
- [ ] Verify tokens with disallowed algorithms are rejected
- [ ] Verify server call site passes `nil` to use the default allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)