### PR TITLE
feat: add gosec, govulncheck, and SBOM generation to CI pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
             fi
             echo "Building ${os}/${arch}..."
             CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
-              go build -ldflags="${LDFLAGS}" -o "dist/${output}" .
+              go build -trimpath -ldflags="${LDFLAGS}" -o "dist/${output}" .
           done
 
       - name: Generate checksums

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,56 @@
+name: Security Scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Mondays
+
+jobs:
+  gosec:
+    name: SAST (gosec)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run gosec
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          gosec ./...
+
+  govulncheck:
+    name: Vulnerability Scanning (govulncheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+      - name: Generate SBOM
+        run: syft packages . -o spdx-json > sbom.spdx.json
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json


### PR DESCRIPTION
## Summary
- Add `security.yml` workflow with gosec SAST scanning on every PR/push to main
- Add govulncheck dependency vulnerability scanning
- Add SBOM generation with syft on main branch pushes (uploaded as artifact)
- Schedule weekly security scans on Monday mornings (06:00 UTC)
- Add `-trimpath` flag to release binary builds for binary hardening

## Fixes
Closes #21

## Test plan
- [ ] Verify gosec workflow triggers on PR
- [ ] Verify govulncheck workflow triggers on PR
- [ ] Verify SBOM is generated and uploaded as artifact on main branch push
- [ ] Verify weekly scheduled runs are configured correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)