### PR TITLE
fix(allowlist): reject spoofed X-Forwarded-For (CWE-290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ The server can be configured via **YAML configuration file** or **environment va
 | `TALOSCTL_OIDC_RATE_LIMIT_REQUESTS` | `rate_limit_requests` | No | `0` | Max requests per IP per window (0 = disabled) |
 | `TALOSCTL_OIDC_RATE_LIMIT_WINDOW` | `rate_limit_window` | No | `1m` | Rate limit time window (e.g., `1m`, `5m`, `1h`) |
 | `TALOSCTL_OIDC_IP_ALLOWLIST` | `ip_allowlist` | No | | Comma-separated list of allowed IPs/CIDRs (empty = allow all) |
+| `TALOSCTL_OIDC_TRUSTED_PROXIES` | `trusted_proxies` | No | | Comma-separated IPs/CIDRs of reverse proxies allowed to set `X-Forwarded-For` (empty = header never trusted) |
 | `DEBUG` | — | No | | Set to any value to enable detailed debug logging (includes RBAC rule evaluation) |
 
 #### TLS Modes
@@ -1013,7 +1014,19 @@ ip_allowlist:
   - 172.16.0.0/16
 ```
 
-**Note:** The server respects the `X-Forwarded-For` header for determining client IP when running behind a reverse proxy. Requests from IPs not in the allowlist receive `403 Forbidden`.
+**Note:** Requests from IPs not in the allowlist receive `403 Forbidden`.
+
+> **Running behind a reverse proxy?** The `X-Forwarded-For` header is only honored when the request's direct peer is listed in `trusted_proxies` (see below). Otherwise the header is attacker-controlled and is ignored in favor of the real connection address — without this, anyone could forge `X-Forwarded-For` to bypass the allowlist.
+
+```bash
+export TALOSCTL_OIDC_TRUSTED_PROXIES="10.0.0.0/8,192.168.0.1"
+```
+
+```yaml
+trusted_proxies:
+  - 10.0.0.0/8
+  - 192.168.0.1
+```
 
 ### Helm Chart Configuration
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -199,7 +199,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var ipAllowlist *allowlist.Allowlist
 	if len(rc.IPAllowlist) > 0 {
 		var err error
-		ipAllowlist, err = allowlist.New(rc.IPAllowlist)
+		ipAllowlist, err = allowlist.New(rc.IPAllowlist, rc.TrustedProxies)
 		if err != nil {
 			return fmt.Errorf("initializing IP allowlist: %w", err)
 		}

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -20,6 +20,12 @@ ip_allowlist:
   - ::1
   - 127.0.0.1
 
+# Reverse proxies allowed to set X-Forwarded-For. When empty, the header is
+# never trusted and the direct connection address is used (spoofing-proof).
+# Set this to your ingress/proxy network so client IPs resolve correctly.
+trusted_proxies: []
+#   - 10.0.0.0/8
+
 # Network Configuration
 listen: ":8443"
 endpoints:

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -10,18 +10,26 @@ import (
 
 // Allowlist manages a list of allowed IP addresses and CIDR ranges.
 type Allowlist struct {
-	nets []net.IPNet
-	ips  []net.IP
+	nets    []net.IPNet
+	ips     []net.IP
+	trusted []net.IPNet // Trusted proxy networks; X-Forwarded-For is only honored from these.
 }
 
 // New creates a new allowlist from a list of CIDR strings or IP addresses.
 // If the list is empty, the allowlist allows all IPs (IsEnabled returns false).
-func New(allowed []string) (*Allowlist, error) {
-	if len(allowed) == 0 {
-		return &Allowlist{}, nil
-	}
-
+//
+// trustedProxies lists CIDRs/IPs of reverse proxies that are allowed to set
+// X-Forwarded-For. When empty, X-Forwarded-For is never trusted and the
+// direct connection address is used instead.
+func New(allowed, trustedProxies []string) (*Allowlist, error) {
 	a := &Allowlist{}
+
+	trusted, err := parseNets(trustedProxies)
+	if err != nil {
+		return nil, err
+	}
+	a.trusted = trusted
+
 	for _, s := range allowed {
 		s = strings.TrimSpace(s)
 		if s == "" {
@@ -46,6 +54,32 @@ func New(allowed []string) (*Allowlist, error) {
 	}
 
 	return a, nil
+}
+
+// parseNets parses a list of CIDRs or single IPs into networks. A bare IP is
+// treated as a host network (/32 or /128).
+func parseNets(entries []string) ([]net.IPNet, error) {
+	var nets []net.IPNet
+	for _, s := range entries {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ipnet, err := net.ParseCIDR(s); err == nil {
+			nets = append(nets, *ipnet)
+			continue
+		}
+		if ip := net.ParseIP(s); ip != nil {
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			nets = append(nets, net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+			continue
+		}
+		return nil, &ParseError{Input: s}
+	}
+	return nets, nil
 }
 
 // ParseError represents an error parsing an allowlist entry.
@@ -96,25 +130,46 @@ func (a *Allowlist) Allowed(ip string) bool {
 	return false
 }
 
-// extractIP extracts the client IP from the request, handling X-Forwarded-For header.
-func extractIP(r *http.Request) string {
-	// Check X-Forwarded-For header first (for requests behind proxy).
-	forwarded := r.Header.Get("X-Forwarded-For")
-	if forwarded != "" {
-		// Take the first IP if multiple are present.
-		ips := strings.Split(forwarded, ",")
-		if len(ips) > 0 {
-			ip := strings.TrimSpace(ips[0])
-			return ip
+// extractIP returns the client IP for allowlist checks.
+//
+// X-Forwarded-For is attacker-controlled, so it is only honored when the
+// direct connection peer (RemoteAddr) is a configured trusted proxy. In that
+// case we walk the header right-to-left and return the first address that is
+// not itself a trusted proxy — the real client as seen by our proxy chain.
+// Otherwise the direct peer address is used, which cannot be spoofed.
+func (a *Allowlist) extractIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+
+	if a.isTrustedProxy(host) {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.Split(xff, ",")
+			for i := len(parts) - 1; i >= 0; i-- {
+				ip := strings.TrimSpace(parts[i])
+				if !a.isTrustedProxy(ip) {
+					return ip
+				}
+			}
 		}
 	}
 
-	// Fall back to RemoteAddr.
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
+	return host
+}
+
+// isTrustedProxy reports whether ip belongs to a configured trusted proxy network.
+func (a *Allowlist) isTrustedProxy(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
 	}
-	return ip
+	for _, n := range a.trusted {
+		if n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
 }
 
 // Middleware returns an HTTP middleware that checks IP allowlisting.
@@ -126,7 +181,7 @@ func (a *Allowlist) Middleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		ip := extractIP(r)
+		ip := a.extractIP(r)
 		if !a.Allowed(ip) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)

--- a/pkg/allowlist/allowlist_test.go
+++ b/pkg/allowlist/allowlist_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestAllowlist_New(t *testing.T) {
 	// Test empty allowlist (allow all).
-	a, err := New([]string{})
+	a, err := New([]string{}, nil)
 	if err != nil {
 		t.Errorf("New() with empty list should not error: %v", err)
 	}
@@ -17,7 +17,7 @@ func TestAllowlist_New(t *testing.T) {
 	}
 
 	// Test with valid IPs.
-	a, err = New([]string{"192.168.1.1", "10.0.0.0/8"})
+	a, err = New([]string{"192.168.1.1", "10.0.0.0/8"}, nil)
 	if err != nil {
 		t.Errorf("New() with valid IPs should not error: %v", err)
 	}
@@ -26,14 +26,14 @@ func TestAllowlist_New(t *testing.T) {
 	}
 
 	// Test with invalid input.
-	_, err = New([]string{"invalid-ip"})
+	_, err = New([]string{"invalid-ip"}, nil)
 	if err == nil {
 		t.Error("New() should error with invalid IP")
 	}
 }
 
 func TestAllowlist_Allowed(t *testing.T) {
-	a, err := New([]string{"192.168.1.0/24", "10.0.0.50"})
+	a, err := New([]string{"192.168.1.0/24", "10.0.0.50"}, nil)
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestAllowlist_Allowed(t *testing.T) {
 
 func TestAllowlist_AllowedEmpty(t *testing.T) {
 	// Empty allowlist should allow all.
-	a, _ := New([]string{})
+	a, _ := New([]string{}, nil)
 
 	tests := []string{"192.168.1.1", "10.0.0.1", "0.0.0.0", "255.255.255.255"}
 	for _, ip := range tests {
@@ -74,7 +74,7 @@ func TestAllowlist_AllowedEmpty(t *testing.T) {
 }
 
 func TestAllowlist_Middleware(t *testing.T) {
-	a, _ := New([]string{"192.168.1.0/24"})
+	a, _ := New([]string{"192.168.1.0/24"}, nil)
 
 	// Create a handler that returns 200.
 	handler := a.Middleware(func(w http.ResponseWriter, r *http.Request) {
@@ -108,6 +108,7 @@ func TestAllowlist_Middleware(t *testing.T) {
 func TestExtractIP(t *testing.T) {
 	tests := []struct {
 		name       string
+		trusted    []string
 		remoteAddr string
 		forwarded  string
 		want       string
@@ -118,28 +119,44 @@ func TestExtractIP(t *testing.T) {
 			want:       "192.168.1.1",
 		},
 		{
-			name:       "X-Forwarded-For single",
+			// Disclosure regression: no trusted proxies configured, so a
+			// spoofed X-Forwarded-For must be ignored in favor of RemoteAddr.
+			name:       "spoofed XFF without trusted proxy is ignored",
+			remoteAddr: "203.0.113.7:12345",
+			forwarded:  "192.168.1.100",
+			want:       "203.0.113.7",
+		},
+		{
+			name:       "XFF honored from trusted proxy",
+			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.0.0.1:12345",
 			forwarded:  "192.168.1.100",
 			want:       "192.168.1.100",
 		},
 		{
-			name:       "X-Forwarded-For multiple",
+			// Right-most untrusted entry is the real client; trailing trusted
+			// hops are skipped, and a spoofed left-most entry cannot win.
+			name:       "XFF chain skips trusted hops",
+			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.0.0.1:12345",
-			forwarded:  "192.168.1.100, 10.0.0.2, 10.0.0.3",
+			forwarded:  "1.1.1.1, 192.168.1.100, 10.0.0.2, 10.0.0.3",
 			want:       "192.168.1.100",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			a, err := New(nil, tt.trusted)
+			if err != nil {
+				t.Fatalf("New() error: %v", err)
+			}
 			req := httptest.NewRequest("GET", "/", nil)
 			req.RemoteAddr = tt.remoteAddr
 			if tt.forwarded != "" {
 				req.Header.Set("X-Forwarded-For", tt.forwarded)
 			}
 
-			got := extractIP(req)
+			got := a.extractIP(req)
 			if got != tt.want {
 				t.Errorf("extractIP() = %v, want %v", got, tt.want)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,11 @@ type FileConfig struct {
 	// IP allowlist configuration.
 	IPAllowlist []string `yaml:"ip_allowlist"` // List of allowed CIDRs/IPs (empty = allow all).
 
+	// Trusted reverse proxies. X-Forwarded-For is only honored when the direct
+	// peer is in this list; otherwise the header is attacker-controlled and
+	// ignored. Empty (default) = never trust X-Forwarded-For.
+	TrustedProxies []string `yaml:"trusted_proxies"`
+
 	// RBAC configuration.
 	RBAC RBACConfig `yaml:"rbac"` // RBAC rules for dynamic role mapping based on OIDC claims.
 }
@@ -103,6 +108,7 @@ type ResolvedConfig struct {
 	RateLimitRequests int
 	RateLimitWindow   time.Duration
 	IPAllowlist       []string
+	TrustedProxies    []string
 	RBAC              RBACConfig // RBAC rules for dynamic role mapping
 }
 
@@ -197,6 +203,13 @@ func Load(configPath string) (*ResolvedConfig, error) {
 		rc.IPAllowlist = strings.Split(envAllowlist, ",")
 	} else if len(fileCfg.IPAllowlist) > 0 {
 		rc.IPAllowlist = fileCfg.IPAllowlist
+	}
+
+	// Trusted proxies: env var (comma-separated) > file.
+	if envTrusted := os.Getenv("TALOSCTL_OIDC_TRUSTED_PROXIES"); envTrusted != "" {
+		rc.TrustedProxies = strings.Split(envTrusted, ",")
+	} else if len(fileCfg.TrustedProxies) > 0 {
+		rc.TrustedProxies = fileCfg.TrustedProxies
 	}
 
 	// RBAC: file config takes precedence for rules; env var can override the entire RBAC config.


### PR DESCRIPTION
## What
Fixes the IP allowlist bypass reported by @rducom (CWE-290).

`extractIP` trusted `X-Forwarded-For` unconditionally, so any client could
forge an allowlisted IP and skip the 403 check.

## Change
- `X-Forwarded-For` is only honored when the request's direct peer is a
  configured trusted proxy. The header is then walked right to left, returning
  the first hop that isn't itself a trusted proxy.
- With no trusted proxies set (the default), the header is ignored and
  `RemoteAddr` is used, which can't be spoofed.
- New `trusted_proxies` config option (`TALOSCTL_OIDC_TRUSTED_PROXIES`),
  documented in the README and `example_config.yaml`.
- Regression test for the spoofing case.
