### PR TITLE
fix(ratelimit): reject spoofed X-Forwarded-For (CWE-290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,6 +993,8 @@ rate_limit_window: "1m"
 
 **Example:** Allow 10 requests per minute per IP. Additional requests receive `429 Too Many Requests` with a `Retry-After` header.
 
+> **Per-IP key behind a proxy:** the rate-limit bucket is keyed on the connection address by default. `X-Forwarded-For` is only used when the request's direct peer is listed in `trusted_proxies` — otherwise a client could rotate the header to mint a fresh bucket on every request, bypassing the limit. Set `trusted_proxies` (env `TALOSCTL_OIDC_TRUSTED_PROXIES`) to your ingress/proxy network.
+
 ### IP Allowlist
 
 IP allowlisting restricts access to the `/exchange` endpoint to specific IP addresses or CIDR ranges.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -187,7 +187,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if window <= 0 {
 			window = time.Minute
 		}
-		rateLimiter = ratelimit.New(rc.RateLimitRequests, window)
+		rateLimiter = ratelimit.New(rc.RateLimitRequests, window, rc.TrustedProxies)
 		cleanupStop := rateLimiter.StartCleanup(5 * time.Minute)
 		defer close(cleanupStop)
 		log.Printf("Rate limiting: enabled (%d requests per %v)", rc.RateLimitRequests, window)

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -18,6 +18,7 @@ type Limiter struct {
 	window   time.Duration // Time window for rate limiting
 	clients  map[string]*client
 	mu       sync.RWMutex
+	trusted  []net.IPNet // Trusted proxy networks; X-Forwarded-For is only honored from these.
 }
 
 // client tracks request timestamps for a single IP.
@@ -28,7 +29,11 @@ type client struct {
 
 // New creates a new rate limiter with the specified request limit and window.
 // If requests is 0, rate limiting is disabled.
-func New(requests int, window time.Duration) *Limiter {
+//
+// trustedProxies lists CIDRs/IPs of reverse proxies allowed to set
+// X-Forwarded-For. When empty, X-Forwarded-For is never trusted and the
+// direct connection address is used as the rate-limit key.
+func New(requests int, window time.Duration, trustedProxies []string) *Limiter {
 	if window <= 0 {
 		window = time.Minute
 	}
@@ -36,7 +41,32 @@ func New(requests int, window time.Duration) *Limiter {
 		requests: requests,
 		window:   window,
 		clients:  make(map[string]*client),
+		trusted:  parseNets(trustedProxies),
 	}
+}
+
+// parseNets parses a list of CIDRs or single IPs into networks. A bare IP is
+// treated as a host network (/32 or /128). Unparseable entries are skipped.
+func parseNets(entries []string) []net.IPNet {
+	var nets []net.IPNet
+	for _, s := range entries {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ipnet, err := net.ParseCIDR(s); err == nil {
+			nets = append(nets, *ipnet)
+			continue
+		}
+		if ip := net.ParseIP(s); ip != nil {
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			nets = append(nets, net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+		}
+	}
+	return nets
 }
 
 // IsEnabled returns true if rate limiting is enabled.
@@ -85,25 +115,47 @@ func (l *Limiter) Allow(ip string) bool {
 	return true
 }
 
-// extractIP extracts the client IP from the request, handling X-Forwarded-For header.
-func extractIP(r *http.Request) string {
-	// Check X-Forwarded-For header first (for requests behind proxy).
-	forwarded := r.Header.Get("X-Forwarded-For")
-	if forwarded != "" {
-		// Take the first IP if multiple are present.
-		ips := strings.Split(forwarded, ",")
-		if len(ips) > 0 {
-			ip := strings.TrimSpace(ips[0])
-			return ip
+// extractIP returns the rate-limit key (client IP) for the request.
+//
+// X-Forwarded-For is attacker-controlled, so it is only honored when the
+// direct connection peer (RemoteAddr) is a configured trusted proxy. In that
+// case we walk the header right-to-left and return the first address that is
+// not itself a trusted proxy — the real client as seen by our proxy chain.
+// Otherwise the direct peer address is used, which cannot be spoofed to mint
+// fresh buckets or exhaust another client's bucket.
+func (l *Limiter) extractIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+
+	if l.isTrustedProxy(host) {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.Split(xff, ",")
+			for i := len(parts) - 1; i >= 0; i-- {
+				ip := strings.TrimSpace(parts[i])
+				if !l.isTrustedProxy(ip) {
+					return ip
+				}
+			}
 		}
 	}
 
-	// Fall back to RemoteAddr.
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
+	return host
+}
+
+// isTrustedProxy reports whether ip belongs to a configured trusted proxy network.
+func (l *Limiter) isTrustedProxy(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
 	}
-	return ip
+	for _, n := range l.trusted {
+		if n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
 }
 
 // Middleware returns an HTTP middleware that applies rate limiting.
@@ -115,7 +167,7 @@ func (l *Limiter) Middleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		ip := extractIP(r)
+		ip := l.extractIP(r)
 		if !l.Allow(ip) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", fmt.Sprintf("%d", int(l.window.Seconds())))

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestRateLimiter_Allow(t *testing.T) {
 	// Test disabled rate limiter (requests = 0).
-	l := New(0, time.Minute)
+	l := New(0, time.Minute, nil)
 	if l.IsEnabled() {
 		t.Error("IsEnabled() should return false when requests is 0 (disabled)")
 	}
 
 	// Test with limit of 2 requests per minute.
-	l = New(2, time.Minute)
+	l = New(2, time.Minute, nil)
 	if !l.IsEnabled() {
 		t.Error("IsEnabled() should return true with positive requests")
 	}
@@ -41,7 +41,7 @@ func TestRateLimiter_Allow(t *testing.T) {
 
 func TestRateLimiter_Window(t *testing.T) {
 	// Test with a very short window.
-	l := New(1, 50*time.Millisecond)
+	l := New(1, 50*time.Millisecond, nil)
 
 	// First request allowed.
 	if !l.Allow("192.168.1.1") {
@@ -63,7 +63,7 @@ func TestRateLimiter_Window(t *testing.T) {
 }
 
 func TestRateLimiter_Middleware(t *testing.T) {
-	l := New(1, time.Minute)
+	l := New(1, time.Minute, nil)
 
 	// Create a simple handler that returns 200.
 	handler := l.Middleware(func(w http.ResponseWriter, r *http.Request) {
@@ -96,6 +96,7 @@ func TestRateLimiter_Middleware(t *testing.T) {
 func TestExtractIP(t *testing.T) {
 	tests := []struct {
 		name       string
+		trusted    []string
 		remoteAddr string
 		forwarded  string
 		want       string
@@ -106,28 +107,40 @@ func TestExtractIP(t *testing.T) {
 			want:       "192.168.1.1",
 		},
 		{
-			name:       "X-Forwarded-For single",
+			// Disclosure regression: with no trusted proxies, a spoofed
+			// X-Forwarded-For must not mint a fresh bucket — the key is the
+			// real connection address.
+			name:       "spoofed XFF without trusted proxy is ignored",
+			remoteAddr: "203.0.113.7:12345",
+			forwarded:  "1.2.3.4",
+			want:       "203.0.113.7",
+		},
+		{
+			name:       "XFF honored from trusted proxy",
+			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.0.0.1:12345",
 			forwarded:  "192.168.1.100",
 			want:       "192.168.1.100",
 		},
 		{
-			name:       "X-Forwarded-For multiple",
+			name:       "XFF chain skips trusted hops",
+			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.0.0.1:12345",
-			forwarded:  "192.168.1.100, 10.0.0.2, 10.0.0.3",
+			forwarded:  "1.1.1.1, 192.168.1.100, 10.0.0.2, 10.0.0.3",
 			want:       "192.168.1.100",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			l := New(1, time.Minute, tt.trusted)
 			req := httptest.NewRequest("GET", "/", nil)
 			req.RemoteAddr = tt.remoteAddr
 			if tt.forwarded != "" {
 				req.Header.Set("X-Forwarded-For", tt.forwarded)
 			}
 
-			got := extractIP(req)
+			got := l.extractIP(req)
 			if got != tt.want {
 				t.Errorf("extractIP() = %v, want %v", got, tt.want)
 			}
@@ -137,7 +150,7 @@ func TestExtractIP(t *testing.T) {
 
 func TestRateLimiter_Cleanup(t *testing.T) {
 	// Create limiter with short window.
-	l := New(10, 100*time.Millisecond)
+	l := New(10, 100*time.Millisecond, nil)
 
 	// Add requests from multiple IPs.
 	l.Allow("192.168.1.1")


### PR DESCRIPTION
## What
Fixes the rate limiter bypass reported by @rducom (CWE-290).

`extractIP` keyed the per-IP bucket on `X-Forwarded-For` unconditionally, so a
client could rotate the header to mint a fresh bucket per request, or pin a
victim's IP to exhaust their bucket.

## Change
- `X-Forwarded-For` is only honored when the request's direct peer is a
  configured trusted proxy, then walked right to left to the first untrusted
  hop.
- With no trusted proxies set (the default), the bucket is keyed on
  `RemoteAddr`.
- New `trusted_proxies` config option (`TALOSCTL_OIDC_TRUSTED_PROXIES`),
  documented in the README and `example_config.yaml`.
- Regression test for the spoofing case.
