### PR TITLE
fix: align docs with code and drop bogus cert_expiry on non-cert audit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ talosctl-oidc login [flags]
 | `--client-id` | Yes | | OIDC client ID |
 | `--server` | Yes | | Cert exchange server URL (e.g. `https://localhost:8443`) |
 | `--client-secret` | No | | OIDC client secret (for confidential clients) |
-| `--scopes` | No | `openid,profile,email` | OIDC scopes |
+| `--scopes` | No | `openid,profile,email,offline_access` | OIDC scopes |
 | `--callback-port` | No | `8900` | Local callback server port |
 | `--context-name` | No | `oidc` | Name for the talosconfig context |
 | `--talosconfig` | No | `~/.talos/config` | Path to talosconfig file |

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -48,7 +48,7 @@ Example configuration file:
     - 10.0.0.2
   # talos_config: /var/run/secrets/talos.dev/config  # empty = in-cluster ServiceAccount
   listen: ":8443"
-  cert_ttl: "1h"
+  cert_ttl: "5m"
   roles:
     - os:admin
   tls_cert: /path/to/tls.crt
@@ -72,7 +72,7 @@ Environment variables (override config file values):
   TALOSCTL_OIDC_CLIENT_SECRET      OIDC client secret (for HS256-signed tokens)
   TALOSCTL_OIDC_CLIENT_SECRET_FILE  Path to file containing OIDC client secret (recommended over flag/env var)
   TALOSCTL_OIDC_LISTEN       Address to listen on (default: ":8443")
-  TALOSCTL_OIDC_CERT_TTL     Certificate lifetime (default: "1h")
+  TALOSCTL_OIDC_CERT_TTL     Certificate lifetime (default: "5m")
   TALOSCTL_OIDC_ROLES        Talos roles, comma-separated (default: "os:admin")
 
 TLS configuration:

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -12,6 +12,14 @@ import (
 	"github.com/qjoly/talosctl-oidc/pkg/audit"
 )
 
+// derefTime returns the zero Time when t is nil.
+func derefTime(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
 // FingerprintFromPEM extracts the SHA-256 fingerprint from a PEM-encoded certificate.
 func FingerprintFromPEM(certPEM []byte) (string, error) {
 	block, _ := pem.Decode(certPEM)
@@ -99,7 +107,7 @@ func (t *Tracker) handleEvent(event audit.Event) {
 			Subject:     event.Subject,
 			Email:       event.Email,
 			IssuedAt:    event.Timestamp,
-			ExpiresAt:   event.CertExpiry,
+			ExpiresAt:   derefTime(event.CertExpiry),
 			ClientIP:    event.ClientIP,
 			Roles:       event.Roles,
 			TTL:         event.CertTTL,

--- a/pkg/admin/certlog.go
+++ b/pkg/admin/certlog.go
@@ -43,7 +43,7 @@ func (l *CertLog) handleEvent(event audit.Event) {
 		Subject:     event.Subject,
 		Email:       event.Email,
 		IssuedAt:    event.Timestamp,
-		ExpiresAt:   event.CertExpiry,
+		ExpiresAt:   derefTime(event.CertExpiry),
 		ClientIP:    event.ClientIP,
 		Roles:       event.Roles,
 		TTL:         event.CertTTL,

--- a/pkg/admin/certlog_test.go
+++ b/pkg/admin/certlog_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/qjoly/talosctl-oidc/pkg/audit"
 )
 
+func ptrTime(t time.Time) *time.Time { return &t }
+
 func TestCertLog_PersistsOnlyCertIssued(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "certs.log")
 	logger, err := audit.NewLogger(filepath.Join(t.TempDir(), "audit.log"))
@@ -34,7 +36,7 @@ func TestCertLog_PersistsOnlyCertIssued(t *testing.T) {
 		ClientIP:        "10.0.0.2",
 		Roles:           []string{"os:reader"},
 		CertTTL:         "1h0m0s",
-		CertExpiry:      time.Unix(1000, 0).UTC(),
+		CertExpiry:      ptrTime(time.Unix(1000, 0).UTC()),
 		CertFingerprint: "abc123",
 	})
 

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -54,7 +54,8 @@ type Event struct {
 	CertTTL string `json:"cert_ttl,omitempty"`
 
 	// CertExpiry is when the issued certificate expires.
-	CertExpiry time.Time `json:"cert_expiry,omitempty"`
+	// Pointer so omitempty drops it on non-cert events (time.Time is never "empty").
+	CertExpiry *time.Time `json:"cert_expiry,omitempty"`
 
 	// CertFingerprint is the SHA-256 fingerprint of the issued certificate.
 	CertFingerprint string `json:"cert_fingerprint,omitempty"`

--- a/pkg/server/admin_dashboard_test.go
+++ b/pkg/server/admin_dashboard_test.go
@@ -198,7 +198,7 @@ func TestAdminDashboardWithActiveCerts(t *testing.T) {
 		ClientIP:   "192.168.1.1",
 		Roles:      []string{"os:admin"},
 		CertTTL:    "1h",
-		CertExpiry: time.Now().Add(time.Hour),
+		CertExpiry: func() *time.Time { t := time.Now().Add(time.Hour); return &t }(),
 		Timestamp:  time.Now(),
 	})
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -658,7 +658,7 @@ func (s *Server) handleExchange(w http.ResponseWriter, r *http.Request) {
 		ClientIP:      clientIP,
 		Roles:         roles,
 		CertTTL:       s.cfg.CertTTL.String(),
-		CertExpiry:    certExpiry,
+		CertExpiry:    &certExpiry,
 		CertFingerprint: fingerprint,
 	})
 


### PR DESCRIPTION
Documentation-vs-code alignment fixes found while auditing the README against the implementation.

## Changes
- **README**: corrected the documented `--scopes` default to `openid,profile,email,offline_access` (matches `cmd/login.go`; `offline_access` is required for the refresh token used by `--watch`).
- **serve --help**: corrected the `cert_ttl` default shown in help/example from `1h` to `5m` (the real default in `pkg/config`).
- **audit**: `Event.CertExpiry` is now `*time.Time` so `omitempty` actually drops it. Previously every event (including `auth_success` / `auth_failure`) emitted `cert_expiry: 0001-01-01T00:00:00Z`, contradicting the README example. Call sites in `pkg/admin` dereference safely (guarded by `EventCertIssued`).

Build passes and `pkg/audit`, `pkg/admin`, `pkg/server` tests are green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLUAB8duggFfDuxTQngJQa)_