### PR TITLE
fix(server): reject non-GET methods on /healthz and /ca (#44)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -481,6 +481,10 @@ func isPathError(err error) bool {
 
 // handleHealth returns a 200 OK for health checks.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, "ok")
 }
@@ -489,6 +493,10 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 // This allows clients to fetch the CA and trust it without out-of-band transfer.
 // In non-self-signed modes, it returns 404.
 func (s *Server) handleCA(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
 	if len(s.selfSignedCAPEM) == 0 {
 		writeError(w, http.StatusNotFound, "CA endpoint only available in self-signed TLS mode")
 		return

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestServer builds a minimal Server suitable for exercising the plain
+// HTTP handlers (/healthz, /ca) that need no OIDC, Talos, or admin wiring.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	return New(Config{ListenAddr: ":8080"})
+}
+
+// TestHandleHealthMethodGuard verifies that /healthz answers GET and rejects
+// every other method with 405 Method Not Allowed (issue #44).
+func TestHandleHealthMethodGuard(t *testing.T) {
+	srv := newTestServer(t)
+
+	t.Run("GET returns 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+	})
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method+" returns 405", func(t *testing.T) {
+			req := httptest.NewRequest(method, "/healthz", nil)
+			rec := httptest.NewRecorder()
+			srv.httpServer.Handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+			}
+		})
+	}
+}
+
+// TestHandleCAMethodGuard verifies that /ca answers GET and rejects every
+// other method with 405 Method Not Allowed (issue #44).
+//
+// The method guard must run before the self-signed-mode check, so a rejected
+// method returns 405 regardless of whether a CA is configured.
+func TestHandleCAMethodGuard(t *testing.T) {
+	srv := newTestServer(t)
+	// Same package: set the unexported CA PEM directly so /ca has content to
+	// serve on the happy path.
+	srv.selfSignedCAPEM = []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n")
+
+	t.Run("GET returns 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/ca", nil)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+	})
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method+" returns 405", func(t *testing.T) {
+			req := httptest.NewRequest(method, "/ca", nil)
+			rec := httptest.NewRecorder()
+			srv.httpServer.Handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`/healthz` and `/ca` are registered with `http.ServeMux`, which matches on
path only and does not filter by method. As a result both endpoints
answered any verb: `POST /healthz`, `DELETE /ca`, and so on all returned
`200` (or the CA PEM) instead of being rejected.

This guards both handlers to return `405 Method Not Allowed` for anything
other than `GET`, mirroring the existing guard in `handleExchange`.

Fixes #44

## Changes

- `handleHealth`: reject non-`GET` with `405` before writing the health response.
- `handleCA`: reject non-`GET` with `405`. The guard runs **before** the
  self-signed-mode check, so method validity is resolved independently of
  server state. A `POST /ca` returns `405` regardless of TLS mode, rather
  than leaking the mode through a `404` vs `405` difference.
- Adds `pkg/server/server_test.go` covering both endpoints: `GET` succeeds,
  and `POST`/`PUT`/`DELETE`/`PATCH` return `405`.

## Testing

- `go test ./...` passes on all packages
- `go vet ./...` is clean

## Open question: should we also allow `HEAD`?

The guard is currently `GET`-only, which keeps it consistent with the
existing `handleExchange` guard. RFC 9110 §9.3.2 says a server that
supports `GET` should also support `HEAD`, and some health-check tooling
probes with `HEAD`, so a strict `GET`-only guard rejects those probes with
`405`.

I kept it `GET`-only for consistency, but I am happy to widen it to
`GET`+`HEAD` if you would prefer:

```go
if r.Method != http.MethodGet && r.Method != http.MethodHead {
    writeError(w, http.StatusMethodNotAllowed, "method not allowed")
    return
}
```

Relatedly, RFC 9110 §15.5.6 says a 405 response should carry an Allow
header. handleExchange does not set one today, so I left it out to match.
I can add Allow: GET (or GET, HEAD) to both handlers if you want the
endpoints to be strictly compliant. Let me know your preference and I will
update the PR.