### PR TITLE
feat(login): allow custom callback listen addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,22 @@ talosctl-oidc login \
   --callback-port 8900
 ```
 
+By default the callback server only listens on `127.0.0.1`. When you log in from
+a remote host, `--listen-address` lets you bind somewhere the browser can reach.
+It can be repeated to serve both address families:
+
+```bash
+talosctl-oidc login \
+  --provider https://idp.example.com/application/o/talos-oidc/ \
+  --client-id <your-client-id> \
+  --server https://localhost:8443 \
+  --listen-address 10.10.10.10:8900 \
+  --listen-address '[fd00::10]:8900'
+```
+
+The first `--listen-address` is the one sent as redirect URI, so it is the one
+to register in your OIDC client.
+
 This will:
 
 1. Open your browser to the OIDC provider login page
@@ -420,7 +436,8 @@ talosctl-oidc login [flags]
 | `--server` | Yes | | Cert exchange server URL (e.g. `https://localhost:8443`) |
 | `--client-secret` | No | | OIDC client secret (for confidential clients) |
 | `--scopes` | No | `openid,profile,email,offline_access` | OIDC scopes |
-| `--callback-port` | No | `8900` | Local callback server port |
+| `--callback-port` | No | `8900` | Local callback server port (shorthand for `--listen-address 127.0.0.1:PORT`) |
+| `--listen-address` | No | `127.0.0.1:8900` | Address the callback server listens on, repeatable. Overrides `--callback-port`; the first one is used as redirect URI |
 | `--context-name` | No | `oidc` | Name for the talosconfig context |
 | `--talosconfig` | No | `~/.talos/config` | Path to talosconfig file |
 | `--server-ca` | No | | Path to PEM CA certificate to trust for the server (for self-signed TLS) |
@@ -1236,7 +1253,7 @@ The OIDC provider is rejecting the token request. Common causes:
 - The provider is configured as a **confidential client** but no `--client-secret` was provided. Either switch to a public client or pass `--client-secret`
 - The **Client ID** is incorrect
 
-### "failed to listen on port 8900"
+### "failed to listen on 127.0.0.1:8900"
 
 Another process is using port 8900. Use `--callback-port` to pick a different port. Make sure the redirect URI in your OIDC provider matches (e.g. `http://127.0.0.1:9000/callback`).
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -36,6 +36,7 @@ var loginFlags struct {
 	clientSecret string
 	scopes       []string
 	callbackPort int
+	listenAddrs  []string
 	serverURL    string
 	contextName  string
 	talosconfig  string
@@ -61,7 +62,8 @@ func init() {
 	loginCmd.Flags().StringVar(&loginFlags.clientID, "client-id", "", "OIDC client ID (required)")
 	loginCmd.Flags().StringVar(&loginFlags.clientSecret, "client-secret", "", "OIDC client secret (optional, for confidential clients)")
 	loginCmd.Flags().StringSliceVar(&loginFlags.scopes, "scopes", []string{"openid", "profile", "email", "offline_access"}, "OIDC scopes")
-	loginCmd.Flags().IntVar(&loginFlags.callbackPort, "callback-port", 8900, "Local callback server port")
+	loginCmd.Flags().IntVar(&loginFlags.callbackPort, "callback-port", 8900, "Local callback server port (shorthand for --listen-address 127.0.0.1:PORT)")
+	loginCmd.Flags().StringSliceVar(&loginFlags.listenAddrs, "listen-address", nil, "Address the callback server listens on, repeatable for dual-stack (e.g. 10.0.0.1:8900, [fd00::1]:8900). Overrides --callback-port; the first one is used as redirect URI")
 	loginCmd.Flags().StringVar(&loginFlags.serverURL, "server", "", "Cert exchange server URL (required, e.g. https://localhost:8443)")
 	loginCmd.Flags().StringVar(&loginFlags.contextName, "context-name", "oidc", "Name for the talosconfig context")
 	loginCmd.Flags().StringVar(&loginFlags.talosconfig, "talosconfig", "", "Path to talosconfig file (default: ~/.talos/config)")
@@ -324,12 +326,12 @@ func obtainIDToken(ctx context.Context) (string, error) {
 	fmt.Printf("Authenticating with OIDC provider: %s\n", loginFlags.provider)
 
 	authCfg := oidc.AuthConfig{
-		IssuerURL:    loginFlags.provider,
-		ClientID:     loginFlags.clientID,
-		ClientSecret: loginFlags.clientSecret,
-		Scopes:       loginFlags.scopes,
-		CallbackPort: loginFlags.callbackPort,
-		OpenBrowser:  openBrowser,
+		IssuerURL:       loginFlags.provider,
+		ClientID:        loginFlags.clientID,
+		ClientSecret:    loginFlags.clientSecret,
+		Scopes:          loginFlags.scopes,
+		ListenAddresses: callbackListenAddresses(),
+		OpenBrowser:     openBrowser,
 	}
 
 	storedToken, err = oidc.Authenticate(ctx, authCfg)
@@ -355,6 +357,15 @@ func obtainIDToken(ctx context.Context) (string, error) {
 	}
 
 	return storedToken.IDToken, nil
+}
+
+// callbackListenAddresses returns the addresses the callback server binds to,
+// falling back to loopback on --callback-port when --listen-address is unset.
+func callbackListenAddresses() []string {
+	if len(loginFlags.listenAddrs) > 0 {
+		return loginFlags.listenAddrs
+	}
+	return []string{fmt.Sprintf("127.0.0.1:%d", loginFlags.callbackPort)}
 }
 
 // exchangeTokenForCert sends the ID token to the cert exchange server and returns the certificate response.

--- a/pkg/oidc/auth.go
+++ b/pkg/oidc/auth.go
@@ -37,25 +37,34 @@ type AuthResult struct {
 
 // CallbackServer manages the local HTTP server that receives the OIDC callback.
 type CallbackServer struct {
-	port     int
-	server   *http.Server
-	listener net.Listener
-	resultCh chan AuthResult
-	errCh    chan error
+	addrs     []string
+	server    *http.Server
+	listeners []net.Listener
+	resultCh  chan AuthResult
+	errCh     chan error
 }
 
-// NewCallbackServer creates a new callback server on the given port.
-func NewCallbackServer(port int) (*CallbackServer, error) {
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	if err != nil {
-		return nil, fmt.Errorf("failed to listen on port %d: %w", port, err)
+// NewCallbackServer listens on every given "host:port" address and serves the
+// callback on all of them, so a dual-stack host can be reached over v4 and v6.
+// The first address is the one advertised as redirect URI.
+func NewCallbackServer(addrs []string) (*CallbackServer, error) {
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no callback listen address configured")
 	}
 
 	cs := &CallbackServer{
-		port:     port,
-		listener: listener,
+		addrs:    addrs,
 		resultCh: make(chan AuthResult, 1),
-		errCh:    make(chan error, 1),
+		errCh:    make(chan error, len(addrs)+1),
+	}
+
+	for _, addr := range addrs {
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			cs.closeListeners()
+			return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
+		}
+		cs.listeners = append(cs.listeners, listener)
 	}
 
 	mux := http.NewServeMux()
@@ -71,18 +80,26 @@ func NewCallbackServer(port int) (*CallbackServer, error) {
 	return cs, nil
 }
 
-// RedirectURI returns the callback URL for this server.
-func (cs *CallbackServer) RedirectURI() string {
-	return fmt.Sprintf("http://127.0.0.1:%d/callback", cs.port)
+func (cs *CallbackServer) closeListeners() {
+	for _, l := range cs.listeners {
+		l.Close()
+	}
 }
 
-// Start begins serving in the background.
+// RedirectURI returns the callback URL built from the first listen address.
+func (cs *CallbackServer) RedirectURI() string {
+	return fmt.Sprintf("http://%s/callback", cs.addrs[0])
+}
+
+// Start begins serving on every listener in the background.
 func (cs *CallbackServer) Start() {
-	go func() {
-		if err := cs.server.Serve(cs.listener); err != nil && err != http.ErrServerClosed {
-			cs.errCh <- err
-		}
-	}()
+	for _, l := range cs.listeners {
+		go func() {
+			if err := cs.server.Serve(l); err != nil && err != http.ErrServerClosed {
+				cs.errCh <- err
+			}
+		}()
+	}
 }
 
 // WaitForCallback blocks until the callback is received or the context is cancelled.
@@ -259,12 +276,12 @@ func Authenticate(ctx context.Context, cfg AuthConfig) (*StoredToken, error) {
 	debug("Generated OIDC state: %s", state)
 
 	// Start the local callback server.
-	callbackServer, err := NewCallbackServer(cfg.CallbackPort)
+	callbackServer, err := NewCallbackServer(cfg.ListenAddresses)
 	if err != nil {
 		return nil, err
 	}
 	callbackServer.Start()
-	debug("Callback server started on port %d", cfg.CallbackPort)
+	debug("Callback server started on %v", cfg.ListenAddresses)
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -340,6 +357,8 @@ type AuthConfig struct {
 	ClientID     string
 	ClientSecret string
 	Scopes       []string
-	CallbackPort int
-	OpenBrowser  func(url string) error
+	// ListenAddresses are the "host:port" the callback server binds to; the
+	// first one is used as the redirect URI.
+	ListenAddresses []string
+	OpenBrowser     func(url string) error
 }

--- a/pkg/oidc/auth_test.go
+++ b/pkg/oidc/auth_test.go
@@ -1,0 +1,77 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// freePort grabs a port the OS just handed out, then releases it.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func TestCallbackServerListensOnEveryAddress(t *testing.T) {
+	addrs := []string{
+		fmt.Sprintf("127.0.0.1:%d", freePort(t)),
+		fmt.Sprintf("127.0.0.1:%d", freePort(t)),
+	}
+
+	cs, err := NewCallbackServer(addrs)
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	cs.Start()
+	defer cs.Shutdown(context.Background())
+
+	if want := "http://" + addrs[0] + "/callback"; cs.RedirectURI() != want {
+		t.Errorf("RedirectURI() = %q, want %q", cs.RedirectURI(), want)
+	}
+
+	// The callback must be answered on the second address too, not only the first.
+	resp, err := http.Get("http://" + addrs[1] + "/callback?code=abc&state=xyz")
+	if err != nil {
+		t.Fatalf("calling second listener: %v", err)
+	}
+	resp.Body.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := cs.WaitForCallback(ctx)
+	if err != nil {
+		t.Fatalf("WaitForCallback: %v", err)
+	}
+	if result.Code != "abc" || result.State != "xyz" {
+		t.Errorf("got code=%q state=%q, want code=abc state=xyz", result.Code, result.State)
+	}
+}
+
+func TestCallbackServerRejectsEmptyAddressList(t *testing.T) {
+	if _, err := NewCallbackServer(nil); err == nil {
+		t.Fatal("expected an error with no listen address")
+	}
+}
+
+func TestCallbackServerReleasesListenersOnBindFailure(t *testing.T) {
+	good := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+
+	if _, err := NewCallbackServer([]string{good, "127.0.0.1:not-a-port"}); err == nil {
+		t.Fatal("expected a bind error")
+	}
+
+	// The first port must be free again, otherwise a retry would fail.
+	l, err := net.Listen("tcp", good)
+	if err != nil {
+		t.Fatalf("port %s left bound after a failed bind: %v", good, err)
+	}
+	l.Close()
+}


### PR DESCRIPTION
Closes #138.

The callback server was hardcoded to `127.0.0.1`, so logging in from a remote host meant setting up an SSH port forward first.

Add a repeatable `--listen-address` flag:

```bash
talosctl-oidc login ... \
  --listen-address 10.10.10.10:8900 \
  --listen-address '[fd00::10]:8900'
```

- every address is bound and served, so a dual-stack host is reachable over v4 and v6
- the first address is the one sent as `redirect_uri`
- `--callback-port` still works and maps to `127.0.0.1:PORT`