### PR TITLE
feat(login): add --skip-open-browser and --browser-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ talosctl-oidc login [flags]
 | `--server-ca` | No | | Path to PEM CA certificate to trust for the server (for self-signed TLS) |
 | `--insecure` | No | `false` | Allow plain HTTP connection to the server |
 | `--watch` | No | `false` | Run in the background and keep the Talos certificate fresh |
+| `--skip-open-browser` | No | `false` | Only print the authorization URL instead of opening a browser |
+| `--browser-command` | No | | Command used to open the authorization URL, instead of the platform default |
 
 ### `logout`
 
@@ -1252,6 +1254,14 @@ The OIDC provider is rejecting the token request. Common causes:
 
 - The provider is configured as a **confidential client** but no `--client-secret` was provided. Either switch to a public client or pass `--client-secret`
 - The **Client ID** is incorrect
+
+### "failed to open browser: exec: \"xdg-open\": executable file not found in $PATH"
+
+The host has no browser opener, which is the usual case over SSH. Use
+`--skip-open-browser` to just print the authorization URL, or `--browser-command`
+to name the binary to run. Remember the callback still has to be reachable from
+wherever you open the URL, so pair it with an SSH port forward or with
+`--listen-address`.
 
 ### "failed to listen on 127.0.0.1:8900"
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -43,6 +43,9 @@ var loginFlags struct {
 	serverCA     string
 	insecure     bool
 	watch        bool
+
+	skipOpenBrowser bool
+	browserCommand  string
 }
 
 var loginCmd = &cobra.Command{
@@ -70,6 +73,8 @@ func init() {
 	loginCmd.Flags().StringVar(&loginFlags.serverCA, "server-ca", "", "Path to PEM CA certificate to trust for the cert exchange server (for self-signed TLS)")
 	loginCmd.Flags().BoolVar(&loginFlags.insecure, "insecure", false, "Allow plain HTTP connection to the cert exchange server (skip TLS verification)")
 	loginCmd.Flags().BoolVar(&loginFlags.watch, "watch", false, "Run in the background and keep the Talos certificate fresh")
+	loginCmd.Flags().BoolVar(&loginFlags.skipOpenBrowser, "skip-open-browser", false, "Only print the authorization URL instead of opening a browser (headless hosts)")
+	loginCmd.Flags().StringVar(&loginFlags.browserCommand, "browser-command", "", "Command used to open the authorization URL, instead of the platform default (e.g. google-chrome)")
 
 	loginCmd.MarkFlagRequired("provider")
 	loginCmd.MarkFlagRequired("client-id")
@@ -414,20 +419,38 @@ func exchangeTokenForCert(ctx context.Context, client *http.Client, serverURL, i
 }
 
 func openBrowser(url string) error {
+	if loginFlags.skipOpenBrowser {
+		fmt.Printf("Open this URL to authenticate:\n  %s\n\n", url)
+		return nil
+	}
+
 	fmt.Printf("Opening browser for authentication...\n")
 	fmt.Printf("If the browser does not open, visit:\n  %s\n\n", url)
 
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "linux":
-		cmd = exec.Command("xdg-open", url)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	default:
-		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	cmd, err := browserCommand(url)
+	if err != nil {
+		return err
 	}
 
 	return cmd.Start()
+}
+
+// browserCommand builds the command that opens url, honouring --browser-command.
+// The URL is passed as a single argument, so no shell quoting is involved; wrap
+// anything more elaborate in a script.
+func browserCommand(url string) (*exec.Cmd, error) {
+	if loginFlags.browserCommand != "" {
+		return exec.Command(loginFlags.browserCommand, url), nil
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url), nil
+	case "linux":
+		return exec.Command("xdg-open", url), nil
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url), nil
+	default:
+		return nil, fmt.Errorf("unsupported platform %s, use --browser-command or --skip-open-browser", runtime.GOOS)
+	}
 }

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenBrowserSkipsExec(t *testing.T) {
+	// A command that cannot exist: openBrowser must not even try to run it.
+	loginFlags.skipOpenBrowser = true
+	loginFlags.browserCommand = "talosctl-oidc-no-such-browser"
+	t.Cleanup(func() { loginFlags.skipOpenBrowser, loginFlags.browserCommand = false, "" })
+
+	if err := openBrowser("https://idp.example.com/auth"); err != nil {
+		t.Fatalf("openBrowser with --skip-open-browser: %v", err)
+	}
+}
+
+func TestBrowserCommandOverridesPlatformDefault(t *testing.T) {
+	loginFlags.browserCommand = "google-chrome"
+	t.Cleanup(func() { loginFlags.browserCommand = "" })
+
+	cmd, err := browserCommand("https://idp.example.com/auth")
+	if err != nil {
+		t.Fatalf("browserCommand: %v", err)
+	}
+	if got := filepath.Base(cmd.Path); got != "google-chrome" {
+		t.Errorf("command = %q, want google-chrome", got)
+	}
+	if len(cmd.Args) != 2 || cmd.Args[1] != "https://idp.example.com/auth" {
+		t.Errorf("args = %v, want the URL as a single argument", cmd.Args)
+	}
+}


### PR DESCRIPTION
Closes #137.

Hosts reached over SSH often have no browser opener, so `login` died on:

```
Error: authentication failed: failed to open browser: exec: "xdg-open": executable file not found in $PATH
```

Two new flags, same names as kubelogin:

- `--skip-open-browser`: print the authorization URL and wait for the callback
- `--browser-command`: name the binary to run instead of the platform default

The URL is passed as a single argument, so no shell is involved.

Note: this only covers the explicit flags. Making an unexpected browser-open failure non-fatal is #132, left for a separate PR.