### PR TITLE
feat(login): device authorization grant, and don't die when the browser won't open

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,28 @@ talosctl-oidc login \
 The first `--listen-address` is the one sent as redirect URI, so it is the one
 to register in your OIDC client.
 
+On a host where no loopback callback is practical at all, `--device-code` uses
+the OAuth device authorization grant (RFC 8628) instead: no browser, no local
+listener, just a URL and a code to enter from another machine.
+
+```bash
+talosctl-oidc login \
+  --provider https://idp.example.com/application/o/talos-oidc/ \
+  --client-id <your-client-id> \
+  --server https://localhost:8443 \
+  --device-code
+```
+
+```
+Open https://idp.example.com/device on any device and enter the code: WDJB-MJHT
+
+Waiting for the login to be approved...
+```
+
+Your OIDC client must have the device flow enabled (in Keycloak, the
+`oauth2DeviceAuthorizationGrantEnabled` toggle) and the provider must advertise
+`device_authorization_endpoint` in its discovery document.
+
 This will:
 
 1. Open your browser to the OIDC provider login page
@@ -445,6 +467,7 @@ talosctl-oidc login [flags]
 | `--watch` | No | `false` | Run in the background and keep the Talos certificate fresh |
 | `--skip-open-browser` | No | `false` | Only print the authorization URL instead of opening a browser |
 | `--browser-command` | No | | Command used to open the authorization URL, instead of the platform default |
+| `--device-code` | No | `false` | Use the OAuth device authorization grant (RFC 8628) instead of the browser callback |
 
 ### `logout`
 
@@ -1257,11 +1280,12 @@ The OIDC provider is rejecting the token request. Common causes:
 
 ### "failed to open browser: exec: \"xdg-open\": executable file not found in $PATH"
 
-The host has no browser opener, which is the usual case over SSH. Use
-`--skip-open-browser` to just print the authorization URL, or `--browser-command`
-to name the binary to run. Remember the callback still has to be reachable from
-wherever you open the URL, so pair it with an SSH port forward or with
-`--listen-address`.
+This is now only a warning: the authorization URL has already been printed and
+the callback server is listening, so the login carries on. Use
+`--skip-open-browser` to silence the attempt entirely, or `--browser-command` to
+name the binary to run. The callback still has to be reachable from wherever you
+open the URL, so pair it with an SSH port forward or with `--listen-address` —
+or use `--device-code`, which needs no local listener at all.
 
 ### "failed to listen on 127.0.0.1:8900"
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -46,6 +46,7 @@ var loginFlags struct {
 
 	skipOpenBrowser bool
 	browserCommand  string
+	deviceCode      bool
 }
 
 var loginCmd = &cobra.Command{
@@ -75,6 +76,7 @@ func init() {
 	loginCmd.Flags().BoolVar(&loginFlags.watch, "watch", false, "Run in the background and keep the Talos certificate fresh")
 	loginCmd.Flags().BoolVar(&loginFlags.skipOpenBrowser, "skip-open-browser", false, "Only print the authorization URL instead of opening a browser (headless hosts)")
 	loginCmd.Flags().StringVar(&loginFlags.browserCommand, "browser-command", "", "Command used to open the authorization URL, instead of the platform default (e.g. google-chrome)")
+	loginCmd.Flags().BoolVar(&loginFlags.deviceCode, "device-code", false, "Use the OAuth device authorization grant (RFC 8628) instead of the browser callback; needs no local listener")
 
 	loginCmd.MarkFlagRequired("provider")
 	loginCmd.MarkFlagRequired("client-id")
@@ -339,7 +341,12 @@ func obtainIDToken(ctx context.Context) (string, error) {
 		OpenBrowser:     openBrowser,
 	}
 
-	storedToken, err = oidc.Authenticate(ctx, authCfg)
+	authenticate := oidc.Authenticate
+	if loginFlags.deviceCode {
+		authenticate = oidc.AuthenticateDevice
+	}
+
+	storedToken, err = authenticate(ctx, authCfg)
 	if err != nil {
 		return "", fmt.Errorf("authentication failed: %w", err)
 	}

--- a/pkg/oidc/auth.go
+++ b/pkg/oidc/auth.go
@@ -295,17 +295,16 @@ func Authenticate(ctx context.Context, cfg AuthConfig) (*StoredToken, error) {
 	debug("Using redirect URI: %s", redirectURI)
 
 	// Build the authorization URL.
-	scopes := cfg.Scopes
-	if len(scopes) == 0 {
-		scopes = []string{"openid", "profile", "email", "offline_access"}
-	}
+	scopes := cfg.scopesOrDefault()
 	authURL := BuildAuthorizationURL(provider, cfg.ClientID, redirectURI, scopes, state, pkce)
 	debug("Full authorization URL: %s", authURL)
 
-	// Open browser.
+	// Open browser. The URL has already been printed at this point and the
+	// callback server is listening, so a failure here is not fatal: the user can
+	// still open it by hand.
 	if cfg.OpenBrowser != nil {
 		if err := cfg.OpenBrowser(authURL); err != nil {
-			return nil, fmt.Errorf("failed to open browser: %w", err)
+			fmt.Fprintf(os.Stderr, "Warning: could not open a browser (%v). Open the URL above manually.\n", err)
 		}
 	}
 
@@ -333,11 +332,48 @@ func Authenticate(ctx context.Context, cfg AuthConfig) (*StoredToken, error) {
 	debug("Token exchange successful (received: access_token=%v, refresh_token=%v, id_token=%v)",
 		tokenResp.AccessToken != "", tokenResp.RefreshToken != "", tokenResp.IDToken != "")
 
-	// Build stored token.
+	return newStoredToken(tokenResp, cfg), nil
+}
+
+// AuthenticateDevice performs the OAuth 2.0 device authorization grant (RFC 8628):
+// it prints a URL and a user code to enter on another device, then polls the token
+// endpoint until the login is approved. No browser and no callback server involved.
+func AuthenticateDevice(ctx context.Context, cfg AuthConfig) (*StoredToken, error) {
+	debug("Starting device authorization flow for issuer: %s", cfg.IssuerURL)
+
+	provider, err := Discover(ctx, cfg.IssuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC discovery failed: %w", err)
+	}
+
+	auth, err := RequestDeviceCode(ctx, provider, cfg.ClientID, cfg.ClientSecret, cfg.scopesOrDefault())
+	if err != nil {
+		return nil, err
+	}
+
+	if auth.VerificationURIComplete != "" {
+		fmt.Printf("Open this URL on any device to authenticate:\n  %s\n\n", auth.VerificationURIComplete)
+		fmt.Printf("If it asks for a code, enter: %s\n\n", auth.UserCode)
+	} else {
+		fmt.Printf("Open %s on any device and enter the code: %s\n\n", auth.VerificationURI, auth.UserCode)
+	}
+	fmt.Println("Waiting for the login to be approved...")
+
+	tokenResp, err := PollDeviceToken(ctx, provider, cfg.ClientID, cfg.ClientSecret, auth)
+	if err != nil {
+		return nil, fmt.Errorf("device authentication failed: %w", err)
+	}
+
+	return newStoredToken(tokenResp, cfg), nil
+}
+
+// newStoredToken turns a token endpoint response into what we persist.
+func newStoredToken(tokenResp *TokenResponse, cfg AuthConfig) *StoredToken {
 	expiresIn := tokenResp.ExpiresIn
 	if expiresIn == 0 {
 		expiresIn = 3600 // Default to 1 hour if not provided.
 	}
+
 	storedToken := &StoredToken{
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
@@ -348,7 +384,7 @@ func Authenticate(ctx context.Context, cfg AuthConfig) (*StoredToken, error) {
 	}
 	debug("Token built and expires at: %s", storedToken.ExpiresAt)
 
-	return storedToken, nil
+	return storedToken
 }
 
 // AuthConfig holds configuration for the OIDC authentication flow.
@@ -361,4 +397,11 @@ type AuthConfig struct {
 	// first one is used as the redirect URI.
 	ListenAddresses []string
 	OpenBrowser     func(url string) error
+}
+
+func (cfg AuthConfig) scopesOrDefault() []string {
+	if len(cfg.Scopes) == 0 {
+		return []string{"openid", "profile", "email", "offline_access"}
+	}
+	return cfg.Scopes
 }

--- a/pkg/oidc/device_test.go
+++ b/pkg/oidc/device_test.go
@@ -1,0 +1,108 @@
+package oidc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRequestDeviceCodeAppliesRFCDefaults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.FormValue("scope"); got != "openid email" {
+			t.Errorf("scope = %q, want %q", got, "openid email")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// No interval and no expires_in: the client must fill in the defaults.
+		w.Write([]byte(`{"device_code":"dc","user_code":"WDJB-MJHT","verification_uri":"https://idp/device"}`))
+	}))
+	defer srv.Close()
+
+	auth, err := RequestDeviceCode(context.Background(), &ProviderConfig{DeviceAuthorizationEndpoint: srv.URL}, "cid", "", []string{"openid", "email"})
+	if err != nil {
+		t.Fatalf("RequestDeviceCode: %v", err)
+	}
+	if auth.Interval != 5 {
+		t.Errorf("Interval = %d, want the RFC default of 5", auth.Interval)
+	}
+	if auth.ExpiresIn != 600 {
+		t.Errorf("ExpiresIn = %d, want the default of 600", auth.ExpiresIn)
+	}
+}
+
+func TestRequestDeviceCodeWithoutEndpoint(t *testing.T) {
+	if _, err := RequestDeviceCode(context.Background(), &ProviderConfig{}, "cid", "", nil); err == nil {
+		t.Fatal("expected an error when the provider advertises no device endpoint")
+	}
+}
+
+func TestPollDeviceTokenSucceedsAfterPending(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if got := r.FormValue("grant_type"); got != deviceCodeGrantType {
+			t.Errorf("grant_type = %q, want %q", got, deviceCodeGrantType)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"authorization_pending"}`))
+			return
+		}
+		w.Write([]byte(`{"access_token":"at","id_token":"it","expires_in":300}`))
+	}))
+	defer srv.Close()
+
+	auth := &DeviceAuth{DeviceCode: "dc", UserCode: "WDJB-MJHT", Interval: 1, ExpiresIn: 60}
+	resp, err := PollDeviceToken(context.Background(), &ProviderConfig{TokenEndpoint: srv.URL}, "cid", "", auth)
+	if err != nil {
+		t.Fatalf("PollDeviceToken: %v", err)
+	}
+	if resp.IDToken != "it" {
+		t.Errorf("IDToken = %q, want %q", resp.IDToken, "it")
+	}
+	if calls != 2 {
+		t.Errorf("polled %d times, want 2", calls)
+	}
+}
+
+func TestPollDeviceTokenSurfacesProviderError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"access_denied","error_description":"user refused"}`))
+	}))
+	defer srv.Close()
+
+	auth := &DeviceAuth{DeviceCode: "dc", Interval: 1, ExpiresIn: 60}
+	_, err := PollDeviceToken(context.Background(), &ProviderConfig{TokenEndpoint: srv.URL}, "cid", "", auth)
+	if err == nil {
+		t.Fatal("expected access_denied to end the polling")
+	}
+}
+
+func TestPollDeviceTokenStopsWhenCodeExpired(t *testing.T) {
+	auth := &DeviceAuth{DeviceCode: "dc", Interval: 1, ExpiresIn: -1}
+	_, err := PollDeviceToken(context.Background(), &ProviderConfig{TokenEndpoint: "http://127.0.0.1:1"}, "cid", "", auth)
+	if err == nil {
+		t.Fatal("expected an expired device code to stop the polling")
+	}
+}
+
+func TestPollDeviceTokenHonoursContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"authorization_pending"}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	auth := &DeviceAuth{DeviceCode: "dc", Interval: 1, ExpiresIn: 600}
+	if _, err := PollDeviceToken(ctx, &ProviderConfig{TokenEndpoint: srv.URL}, "cid", "", auth); err == nil {
+		t.Fatal("expected the poll to stop when the context expires")
+	}
+}

--- a/pkg/oidc/provider.go
+++ b/pkg/oidc/provider.go
@@ -23,6 +23,29 @@ var oidcHTTPClient = &http.Client{
 	},
 }
 
+// postForm sends a form-encoded POST to endpoint and returns the status and body.
+func postForm(ctx context.Context, endpoint string, data url.Values) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return 0, nil, fmt.Errorf("creating request for %s: %w", endpoint, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := oidcHTTPClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	resp.Body = http.MaxBytesReader(nil, resp.Body, 1<<20) // 1 MB limit
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("reading response from %s: %w", endpoint, err)
+	}
+
+	return resp.StatusCode, body, nil
+}
+
 // ProviderConfig holds the OIDC provider discovery information.
 type ProviderConfig struct {
 	Issuer                string `json:"issuer"`
@@ -30,6 +53,8 @@ type ProviderConfig struct {
 	TokenEndpoint         string `json:"token_endpoint"`
 	UserinfoEndpoint      string `json:"userinfo_endpoint"`
 	JWKSURI               string `json:"jwks_uri"`
+
+	DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
 }
 
 // Discover fetches OIDC provider metadata from the well-known endpoint.
@@ -158,30 +183,17 @@ func ExchangeCode(ctx context.Context, provider *ProviderConfig, clientID, clien
 		data.Set("client_secret", clientSecret)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.TokenEndpoint, strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("creating token request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := oidcHTTPClient.Do(req)
+	status, body, err := postForm(ctx, provider.TokenEndpoint, data)
 	if err != nil {
 		return nil, fmt.Errorf("exchanging authorization code: %w", err)
 	}
-	defer resp.Body.Close()
-	resp.Body = http.MaxBytesReader(nil, resp.Body, 1<<20) // 1 MB limit
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		debug("Token exchange failed: status=%d, body=%s", resp.StatusCode, string(body))
-		return nil, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, string(body))
+	if status != http.StatusOK {
+		debug("Token exchange failed: status=%d, body=%s", status, string(body))
+		return nil, fmt.Errorf("token endpoint returned status %d: %s", status, string(body))
 	}
 
 	var tokenResp TokenResponse
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading token response: %w", err)
-	}
 	debug("Raw token response: %s", string(body))
 
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
@@ -212,30 +224,17 @@ func RefreshAccessToken(ctx context.Context, provider *ProviderConfig, clientID,
 		data.Set("client_secret", clientSecret)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.TokenEndpoint, strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("creating refresh request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := oidcHTTPClient.Do(req)
+	status, body, err := postForm(ctx, provider.TokenEndpoint, data)
 	if err != nil {
 		return nil, fmt.Errorf("refreshing token: %w", err)
 	}
-	defer resp.Body.Close()
-	resp.Body = http.MaxBytesReader(nil, resp.Body, 1<<20) // 1 MB limit
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		debug("Token refresh failed: status=%d, body=%s", resp.StatusCode, string(body))
-		return nil, fmt.Errorf("token refresh returned status %d: %s", resp.StatusCode, string(body))
+	if status != http.StatusOK {
+		debug("Token refresh failed: status=%d, body=%s", status, string(body))
+		return nil, fmt.Errorf("token refresh returned status %d: %s", status, string(body))
 	}
 
 	var tokenResp TokenResponse
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading refresh response: %w", err)
-	}
 	debug("Raw refresh response: %s", string(body))
 
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
@@ -245,4 +244,123 @@ func RefreshAccessToken(ctx context.Context, provider *ProviderConfig, clientID,
 		tokenResp.AccessToken != "", tokenResp.RefreshToken != "", tokenResp.IDToken != "", tokenResp.ExpiresIn, tokenResp.Scope)
 
 	return &tokenResp, nil
+}
+
+// deviceCodeGrantType is the grant_type of RFC 8628.
+const deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+// DeviceAuth is the device authorization response (RFC 8628 section 3.2).
+type DeviceAuth struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// RequestDeviceCode starts a device authorization grant.
+func RequestDeviceCode(ctx context.Context, provider *ProviderConfig, clientID, clientSecret string, scopes []string) (*DeviceAuth, error) {
+	if provider.DeviceAuthorizationEndpoint == "" {
+		return nil, fmt.Errorf("the OIDC provider does not advertise a device_authorization_endpoint; enable the device flow for this client")
+	}
+	debug("Requesting device code at %s for client_id=%s", provider.DeviceAuthorizationEndpoint, clientID)
+
+	data := url.Values{"client_id": {clientID}}
+	if len(scopes) > 0 {
+		data.Set("scope", strings.Join(scopes, " "))
+	}
+	if clientSecret != "" {
+		data.Set("client_secret", clientSecret)
+	}
+
+	status, body, err := postForm(ctx, provider.DeviceAuthorizationEndpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("requesting device code: %w", err)
+	}
+
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("device authorization endpoint returned status %d: %s", status, string(body))
+	}
+
+	var auth DeviceAuth
+	if err := json.Unmarshal(body, &auth); err != nil {
+		return nil, fmt.Errorf("decoding device authorization response: %w", err)
+	}
+	if auth.DeviceCode == "" || auth.UserCode == "" {
+		return nil, fmt.Errorf("device authorization response is missing device_code or user_code")
+	}
+
+	// Defaults from RFC 8628 section 3.2 when the provider stays silent.
+	if auth.Interval <= 0 {
+		auth.Interval = 5
+	}
+	if auth.ExpiresIn <= 0 {
+		auth.ExpiresIn = 600
+	}
+	debug("Device code obtained: user_code=%s, interval=%ds, expires_in=%ds", auth.UserCode, auth.Interval, auth.ExpiresIn)
+
+	return &auth, nil
+}
+
+// PollDeviceToken polls the token endpoint until the user approves the request,
+// the device code expires, or ctx is cancelled.
+func PollDeviceToken(ctx context.Context, provider *ProviderConfig, clientID, clientSecret string, auth *DeviceAuth) (*TokenResponse, error) {
+	data := url.Values{
+		"grant_type":  {deviceCodeGrantType},
+		"device_code": {auth.DeviceCode},
+		"client_id":   {clientID},
+	}
+	if clientSecret != "" {
+		data.Set("client_secret", clientSecret)
+	}
+
+	interval := time.Duration(auth.Interval) * time.Second
+	deadline := time.Now().Add(time.Duration(auth.ExpiresIn) * time.Second)
+
+	for {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("device code expired before the login was approved")
+		}
+
+		status, body, err := postForm(ctx, provider.TokenEndpoint, data)
+		if err != nil {
+			return nil, fmt.Errorf("polling for the device token: %w", err)
+		}
+
+		if status == http.StatusOK {
+			var tokenResp TokenResponse
+			if err := json.Unmarshal(body, &tokenResp); err != nil {
+				return nil, fmt.Errorf("decoding device token response: %w", err)
+			}
+			debug("Device token response: access_token=%v, refresh_token=%v, id_token=%v",
+				tokenResp.AccessToken != "", tokenResp.RefreshToken != "", tokenResp.IDToken != "")
+			return &tokenResp, nil
+		}
+
+		var errResp struct {
+			Error       string `json:"error"`
+			Description string `json:"error_description"`
+		}
+		if json.Unmarshal(body, &errResp) != nil || errResp.Error == "" {
+			return nil, fmt.Errorf("token endpoint returned status %d: %s", status, string(body))
+		}
+
+		switch errResp.Error {
+		case "authorization_pending":
+			debug("Device authorization still pending")
+		case "slow_down":
+			// RFC 8628 section 3.5: bump the interval by 5s and keep going.
+			interval += 5 * time.Second
+			debug("Provider asked to slow down, polling every %s", interval)
+		default:
+			return nil, fmt.Errorf("device authorization failed: %s: %s", errResp.Error, errResp.Description)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
 }


### PR DESCRIPTION
Closes #132.

**1. Browser-open failure is no longer fatal.**

The URL is printed and the callback server is already listening when the browser attempt happens, so an `xdg-open` that is missing now only logs a warning and the login continues. That makes the printed-URL + SSH-port-forward workflow work out of the box, as the message already promised.

The `--no-browser` flag asked for in the issue landed in #143 as `--skip-open-browser`.

**2. Device authorization grant (RFC 8628).**

`--device-code` skips the browser and the local listener entirely:

```
Open https://idp.example.com/device on any device and enter the code: WDJB-MJHT

Waiting for the login to be approved...
```

- reads `device_authorization_endpoint` from discovery, errors clearly if the provider does not advertise it
- handles `authorization_pending`, `slow_down` (+5s), and terminal errors
- applies the RFC defaults for `interval` and `expires_in`

Token POSTs now go through a shared `postForm` helper, so device polling reuses the existing timeouts and 1 MB body limit rather than duplicating them.