### PR TITLE
feat(login): serve the callback over HTTPS with a custom redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,39 @@ talosctl-oidc login \
 The first `--listen-address` is the one sent as redirect URI, so it is the one
 to register in your OIDC client.
 
+Some providers (Kanidm, for instance) refuse plain-HTTP redirect URIs. Give the
+callback server a certificate and key, and it serves HTTPS instead:
+
+```bash
+talosctl-oidc login \
+  --provider https://idp.example.com/oauth2/openid/talos \
+  --client-id <your-client-id> \
+  --server https://localhost:8443 \
+  --listen-address 127.0.0.1:8900 \
+  --local-server-cert callback.crt \
+  --local-server-key callback.key
+```
+
+The redirect URI then becomes `https://127.0.0.1:8900/callback`. The browser
+must trust that certificate, so use one signed by a CA your system knows (mkcert
+works well for local development).
+
+If the URI registered in your OIDC client differs from the address you bind to —
+TLS terminated by a reverse proxy, a hostname instead of an IP, another path —
+`--oidc-redirect-url` sends that exact URI to the provider:
+
+```bash
+talosctl-oidc login \
+  --provider https://idp.example.com/oauth2/openid/talos \
+  --client-id <your-client-id> \
+  --server https://localhost:8443 \
+  --listen-address 0.0.0.0:8900 \
+  --oidc-redirect-url https://talos.example.com/callback
+```
+
+The callback server also answers on the path of that URL, so a redirect URI
+pointing at `/oidc/cb` works without extra setup.
+
 On a host where no loopback callback is practical at all, `--device-code` uses
 the OAuth device authorization grant (RFC 8628) instead: no browser, no local
 listener, just a URL and a code to enter from another machine.
@@ -460,6 +493,9 @@ talosctl-oidc login [flags]
 | `--scopes` | No | `openid,profile,email,offline_access` | OIDC scopes |
 | `--callback-port` | No | `8900` | Local callback server port (shorthand for `--listen-address 127.0.0.1:PORT`) |
 | `--listen-address` | No | `127.0.0.1:8900` | Address the callback server listens on, repeatable. Overrides `--callback-port`; the first one is used as redirect URI |
+| `--oidc-redirect-url` | No | | Redirect URI advertised to the OIDC provider, when it differs from the listen address |
+| `--local-server-cert` | No | | Path to a PEM certificate to serve the local callback over HTTPS (requires `--local-server-key`) |
+| `--local-server-key` | No | | Path to the PEM private key matching `--local-server-cert` |
 | `--context-name` | No | `oidc` | Name for the talosconfig context |
 | `--talosconfig` | No | `~/.talos/config` | Path to talosconfig file |
 | `--server-ca` | No | | Path to PEM CA certificate to trust for the server (for self-signed TLS) |

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -93,6 +94,12 @@ func init() {
 
 func runLogin(cmd *cobra.Command, args []string) error {
 	debug("Login command started")
+
+	loginFlags.talosconfig = expandHome(loginFlags.talosconfig)
+	loginFlags.serverCA = expandHome(loginFlags.serverCA)
+	loginFlags.localCert = expandHome(loginFlags.localCert)
+	loginFlags.localKey = expandHome(loginFlags.localKey)
+
 	talosconfigPath := loginFlags.talosconfig
 	if talosconfigPath == "" {
 		var err error
@@ -224,6 +231,21 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// expandHome resolves a leading ~, which no shell expands when the path comes
+// from a config file, a systemd unit or a quoted argument.
+func expandHome(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+
+	return filepath.Join(home, strings.TrimPrefix(path, "~"))
 }
 
 // buildHTTPClient creates an HTTP client with the appropriate TLS configuration.

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -37,6 +37,9 @@ var loginFlags struct {
 	scopes       []string
 	callbackPort int
 	listenAddrs  []string
+	redirectURL  string
+	localCert    string
+	localKey     string
 	serverURL    string
 	contextName  string
 	talosconfig  string
@@ -68,6 +71,9 @@ func init() {
 	loginCmd.Flags().StringSliceVar(&loginFlags.scopes, "scopes", []string{"openid", "profile", "email", "offline_access"}, "OIDC scopes")
 	loginCmd.Flags().IntVar(&loginFlags.callbackPort, "callback-port", 8900, "Local callback server port (shorthand for --listen-address 127.0.0.1:PORT)")
 	loginCmd.Flags().StringSliceVar(&loginFlags.listenAddrs, "listen-address", nil, "Address the callback server listens on, repeatable for dual-stack (e.g. 10.0.0.1:8900, [fd00::1]:8900). Overrides --callback-port; the first one is used as redirect URI")
+	loginCmd.Flags().StringVar(&loginFlags.redirectURL, "oidc-redirect-url", "", "Redirect URI advertised to the OIDC provider, when it differs from the listen address (e.g. https://talos.example.com:8900/callback)")
+	loginCmd.Flags().StringVar(&loginFlags.localCert, "local-server-cert", "", "Path to a PEM certificate to serve the local callback over HTTPS (requires --local-server-key)")
+	loginCmd.Flags().StringVar(&loginFlags.localKey, "local-server-key", "", "Path to the PEM private key matching --local-server-cert")
 	loginCmd.Flags().StringVar(&loginFlags.serverURL, "server", "", "Cert exchange server URL (required, e.g. https://localhost:8443)")
 	loginCmd.Flags().StringVar(&loginFlags.contextName, "context-name", "oidc", "Name for the talosconfig context")
 	loginCmd.Flags().StringVar(&loginFlags.talosconfig, "talosconfig", "", "Path to talosconfig file (default: ~/.talos/config)")
@@ -338,6 +344,9 @@ func obtainIDToken(ctx context.Context) (string, error) {
 		ClientSecret:    loginFlags.clientSecret,
 		Scopes:          loginFlags.scopes,
 		ListenAddresses: callbackListenAddresses(),
+		RedirectURL:     loginFlags.redirectURL,
+		TLSCertFile:     loginFlags.localCert,
+		TLSKeyFile:      loginFlags.localKey,
 		OpenBrowser:     openBrowser,
 	}
 

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,5 +30,28 @@ func TestBrowserCommandOverridesPlatformDefault(t *testing.T) {
 	}
 	if len(cmd.Args) != 2 || cmd.Args[1] != "https://idp.example.com/auth" {
 		t.Errorf("args = %v, want the URL as a single argument", cmd.Args)
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory: %v", err)
+	}
+
+	cases := map[string]string{
+		"~/.talos/oidc.crt": filepath.Join(home, ".talos/oidc.crt"),
+		"~":                 home,
+		"/etc/tls/oidc.crt": "/etc/tls/oidc.crt",
+		"oidc.crt":          "oidc.crt",
+		"":                  "",
+		// Another user's home is a shell feature we do not reimplement.
+		"~other/oidc.crt": "~other/oidc.crt",
+	}
+
+	for in, want := range cases {
+		if got := expandHome(in); got != want {
+			t.Errorf("expandHome(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/pkg/oidc/auth.go
+++ b/pkg/oidc/auth.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -37,28 +39,62 @@ type AuthResult struct {
 
 // CallbackServer manages the local HTTP server that receives the OIDC callback.
 type CallbackServer struct {
-	addrs     []string
-	server    *http.Server
-	listeners []net.Listener
-	resultCh  chan AuthResult
-	errCh     chan error
+	addrs       []string
+	redirectURI string
+	useTLS      bool
+	server      *http.Server
+	listeners   []net.Listener
+	resultCh    chan AuthResult
+	errCh       chan error
 }
 
-// NewCallbackServer listens on every given "host:port" address and serves the
-// callback on all of them, so a dual-stack host can be reached over v4 and v6.
-// The first address is the one advertised as redirect URI.
-func NewCallbackServer(addrs []string) (*CallbackServer, error) {
-	if len(addrs) == 0 {
+// NewCallbackServer listens on every "host:port" in cfg.ListenAddresses and
+// serves the callback on all of them, so a dual-stack host can be reached over
+// v4 and v6. The redirect URI is derived from the first address, unless
+// cfg.RedirectURL overrides it; a cert/key pair makes the listeners speak TLS.
+func NewCallbackServer(cfg AuthConfig) (*CallbackServer, error) {
+	if len(cfg.ListenAddresses) == 0 {
 		return nil, fmt.Errorf("no callback listen address configured")
 	}
 
-	cs := &CallbackServer{
-		addrs:    addrs,
-		resultCh: make(chan AuthResult, 1),
-		errCh:    make(chan error, len(addrs)+1),
+	tlsConfig, err := cfg.callbackTLSConfig()
+	if err != nil {
+		return nil, err
 	}
 
-	for _, addr := range addrs {
+	cs := &CallbackServer{
+		addrs:    cfg.ListenAddresses,
+		useTLS:   tlsConfig != nil,
+		resultCh: make(chan AuthResult, 1),
+		errCh:    make(chan error, len(cfg.ListenAddresses)+1),
+	}
+
+	scheme := "http"
+	if cs.useTLS {
+		scheme = "https"
+	}
+	cs.redirectURI = fmt.Sprintf("%s://%s/callback", scheme, cfg.ListenAddresses[0])
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", cs.handleCallback)
+	mux.HandleFunc("/logo", handleLogo)
+
+	if cfg.RedirectURL != "" {
+		u, err := url.Parse(cfg.RedirectURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid redirect URL %q: %w", cfg.RedirectURL, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("redirect URL %q must be absolute, e.g. https://talos.example.com:8900/callback", cfg.RedirectURL)
+		}
+		// The provider sends the browser to that exact path, so answer on it too.
+		if u.Path != "" && u.Path != "/" && u.Path != "/callback" {
+			mux.HandleFunc(u.Path, cs.handleCallback)
+		}
+		cs.redirectURI = cfg.RedirectURL
+	}
+
+	for _, addr := range cfg.ListenAddresses {
 		listener, err := net.Listen("tcp", addr)
 		if err != nil {
 			cs.closeListeners()
@@ -67,12 +103,9 @@ func NewCallbackServer(addrs []string) (*CallbackServer, error) {
 		cs.listeners = append(cs.listeners, listener)
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/callback", cs.handleCallback)
-	mux.HandleFunc("/logo", handleLogo)
-
 	cs.server = &http.Server{
 		Handler:      mux,
+		TLSConfig:    tlsConfig,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}
@@ -86,16 +119,23 @@ func (cs *CallbackServer) closeListeners() {
 	}
 }
 
-// RedirectURI returns the callback URL built from the first listen address.
+// RedirectURI returns the callback URL advertised to the OIDC provider.
 func (cs *CallbackServer) RedirectURI() string {
-	return fmt.Sprintf("http://%s/callback", cs.addrs[0])
+	return cs.redirectURI
 }
 
 // Start begins serving on every listener in the background.
 func (cs *CallbackServer) Start() {
 	for _, l := range cs.listeners {
 		go func() {
-			if err := cs.server.Serve(l); err != nil && err != http.ErrServerClosed {
+			var err error
+			if cs.useTLS {
+				// The key pair already lives in server.TLSConfig.
+				err = cs.server.ServeTLS(l, "", "")
+			} else {
+				err = cs.server.Serve(l)
+			}
+			if err != nil && err != http.ErrServerClosed {
 				cs.errCh <- err
 			}
 		}()
@@ -276,7 +316,7 @@ func Authenticate(ctx context.Context, cfg AuthConfig) (*StoredToken, error) {
 	debug("Generated OIDC state: %s", state)
 
 	// Start the local callback server.
-	callbackServer, err := NewCallbackServer(cfg.ListenAddresses)
+	callbackServer, err := NewCallbackServer(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +436,33 @@ type AuthConfig struct {
 	// ListenAddresses are the "host:port" the callback server binds to; the
 	// first one is used as the redirect URI.
 	ListenAddresses []string
-	OpenBrowser     func(url string) error
+	// RedirectURL overrides the redirect URI sent to the provider, for providers
+	// that reject loopback or plain-HTTP callbacks.
+	RedirectURL string
+	// TLSCertFile and TLSKeyFile make the callback server serve HTTPS.
+	TLSCertFile string
+	TLSKeyFile  string
+	OpenBrowser func(url string) error
+}
+
+// callbackTLSConfig returns nil when the callback server should stay on plain HTTP.
+func (cfg AuthConfig) callbackTLSConfig() (*tls.Config, error) {
+	if cfg.TLSCertFile == "" && cfg.TLSKeyFile == "" {
+		return nil, nil
+	}
+	if cfg.TLSCertFile == "" || cfg.TLSKeyFile == "" {
+		return nil, fmt.Errorf("serving the callback over TLS needs both a certificate and a key")
+	}
+
+	cert, err := tls.LoadX509KeyPair(cfg.TLSCertFile, cfg.TLSKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading callback TLS key pair: %w", err)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
 }
 
 func (cfg AuthConfig) scopesOrDefault() []string {

--- a/pkg/oidc/auth_test.go
+++ b/pkg/oidc/auth_test.go
@@ -2,9 +2,21 @@ package oidc
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -26,7 +38,7 @@ func TestCallbackServerListensOnEveryAddress(t *testing.T) {
 		fmt.Sprintf("127.0.0.1:%d", freePort(t)),
 	}
 
-	cs, err := NewCallbackServer(addrs)
+	cs, err := NewCallbackServer(AuthConfig{ListenAddresses: addrs})
 	if err != nil {
 		t.Fatalf("NewCallbackServer: %v", err)
 	}
@@ -56,7 +68,7 @@ func TestCallbackServerListensOnEveryAddress(t *testing.T) {
 }
 
 func TestCallbackServerRejectsEmptyAddressList(t *testing.T) {
-	if _, err := NewCallbackServer(nil); err == nil {
+	if _, err := NewCallbackServer(AuthConfig{}); err == nil {
 		t.Fatal("expected an error with no listen address")
 	}
 }
@@ -64,7 +76,7 @@ func TestCallbackServerRejectsEmptyAddressList(t *testing.T) {
 func TestCallbackServerReleasesListenersOnBindFailure(t *testing.T) {
 	good := fmt.Sprintf("127.0.0.1:%d", freePort(t))
 
-	if _, err := NewCallbackServer([]string{good, "127.0.0.1:not-a-port"}); err == nil {
+	if _, err := NewCallbackServer(AuthConfig{ListenAddresses: []string{good, "127.0.0.1:not-a-port"}}); err == nil {
 		t.Fatal("expected a bind error")
 	}
 
@@ -74,4 +86,205 @@ func TestCallbackServerReleasesListenersOnBindFailure(t *testing.T) {
 		t.Fatalf("port %s left bound after a failed bind: %v", good, err)
 	}
 	l.Close()
+}
+
+// selfSignedPair writes a throwaway cert/key valid for 127.0.0.1 and returns their paths.
+func selfSignedPair(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:         true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	write := func(path, blockType string, der []byte) {
+		if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	write(certPath, "CERTIFICATE", der)
+	write(keyPath, "EC PRIVATE KEY", keyDER)
+
+	return certPath, keyPath
+}
+
+func TestCallbackServerServesTLSAndAdvertisesHTTPS(t *testing.T) {
+	certPath, keyPath := selfSignedPair(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+
+	cs, err := NewCallbackServer(AuthConfig{
+		ListenAddresses: []string{addr},
+		TLSCertFile:     certPath,
+		TLSKeyFile:      keyPath,
+	})
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	cs.Start()
+	defer cs.Shutdown(context.Background())
+
+	if want := "https://" + addr + "/callback"; cs.RedirectURI() != want {
+		t.Errorf("RedirectURI() = %q, want %q", cs.RedirectURI(), want)
+	}
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // self-signed test cert
+	}}
+	resp, err := client.Get("https://" + addr + "/callback?code=abc&state=xyz")
+	if err != nil {
+		t.Fatalf("calling HTTPS callback: %v", err)
+	}
+	resp.Body.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := cs.WaitForCallback(ctx)
+	if err != nil {
+		t.Fatalf("WaitForCallback: %v", err)
+	}
+	if result.Code != "abc" {
+		t.Errorf("code = %q, want abc", result.Code)
+	}
+}
+
+func TestCallbackServerRejectsHalfTLSPair(t *testing.T) {
+	certPath, _ := selfSignedPair(t)
+
+	if _, err := NewCallbackServer(AuthConfig{
+		ListenAddresses: []string{fmt.Sprintf("127.0.0.1:%d", freePort(t))},
+		TLSCertFile:     certPath,
+	}); err == nil {
+		t.Fatal("expected an error when only the certificate is given")
+	}
+}
+
+func TestCallbackServerUsesCustomRedirectURL(t *testing.T) {
+	addr := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+	redirect := "https://talos.example.com:8900/oidc/cb"
+
+	cs, err := NewCallbackServer(AuthConfig{
+		ListenAddresses: []string{addr},
+		RedirectURL:     redirect,
+	})
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	cs.Start()
+	defer cs.Shutdown(context.Background())
+
+	if cs.RedirectURI() != redirect {
+		t.Errorf("RedirectURI() = %q, want %q", cs.RedirectURI(), redirect)
+	}
+
+	// The provider redirects to the custom path, so the server must answer there.
+	resp, err := http.Get("http://" + addr + "/oidc/cb?code=abc&state=xyz")
+	if err != nil {
+		t.Fatalf("calling custom callback path: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := cs.WaitForCallback(ctx); err != nil {
+		t.Fatalf("WaitForCallback: %v", err)
+	}
+}
+
+func TestCallbackServerRejectsRelativeRedirectURL(t *testing.T) {
+	if _, err := NewCallbackServer(AuthConfig{
+		ListenAddresses: []string{fmt.Sprintf("127.0.0.1:%d", freePort(t))},
+		RedirectURL:     "/callback",
+	}); err == nil {
+		t.Fatal("expected an error for a relative redirect URL")
+	}
+}
+
+// TestAuthenticateUsesConfiguredRedirectURI walks the whole code flow against a
+// fake provider: the URI must be identical in the authorization request and in
+// the token exchange, which is what strict providers check.
+func TestAuthenticateUsesConfiguredRedirectURI(t *testing.T) {
+	addr := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+	redirect := "http://" + addr + "/oidc/cb"
+
+	var tokenRedirect string
+	mux := http.NewServeMux()
+	provider := httptest.NewServer(mux)
+	defer provider.Close()
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"issuer":%q,"authorization_endpoint":%q,"token_endpoint":%q}`,
+			provider.URL, provider.URL+"/auth", provider.URL+"/token")
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		tokenRedirect = r.FormValue("redirect_uri")
+		fmt.Fprint(w, `{"access_token":"at","id_token":"it","refresh_token":"rt","expires_in":3600}`)
+	})
+
+	var authRedirect string
+	openBrowser := func(rawURL string) error {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return err
+		}
+		authRedirect = u.Query().Get("redirect_uri")
+
+		// Play the provider: bounce the browser back to the callback.
+		resp, err := http.Get(fmt.Sprintf("%s?code=the-code&state=%s", authRedirect, u.Query().Get("state")))
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	token, err := Authenticate(ctx, AuthConfig{
+		IssuerURL:       provider.URL,
+		ClientID:        "talosctl-oidc",
+		ListenAddresses: []string{addr},
+		RedirectURL:     redirect,
+		OpenBrowser:     openBrowser,
+	})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if token.IDToken != "it" {
+		t.Errorf("IDToken = %q, want it", token.IDToken)
+	}
+	if authRedirect != redirect {
+		t.Errorf("authorization redirect_uri = %q, want %q", authRedirect, redirect)
+	}
+	if tokenRedirect != redirect {
+		t.Errorf("token redirect_uri = %q, want %q", tokenRedirect, redirect)
+	}
 }


### PR DESCRIPTION
Closes #145

Kanidm rejects plain-HTTP redirect URIs, so the local callback server needs to serve HTTPS. Two flags, named after their kubelogin equivalents.

`--local-server-cert` and `--local-server-key` make the callback listener serve HTTPS. The redirect URI becomes `https://host:port/callback`.

`--oidc-redirect-url` sends that exact URI to the provider instead of building it from the listen address, for a reverse proxy or a hostname. The listener answers on the path of that URL too.

```bash
talosctl-oidc login \
  --provider https://kanidm.example.com/oauth2/openid/talos \
  --client-id talos --server https://localhost:8443 \
  --local-server-cert callback.crt --local-server-key callback.key
```

The browser has to trust the cert, so mkcert is the easy path locally.

The key pair loads before anything binds, so a wrong path fails right away instead of showing up later from a goroutine. It also refuses a cert without its key, and a relative redirect URL.

Tests: a real HTTPS listener with a self-signed cert, the custom redirect path, and a full `Authenticate` run against a fake provider checking the redirect URI is the same in the authorization request and in the token exchange.

Second commit: `~` in a path flag was passed through literally, which Kariton hit while testing. Now expanded for the four path flags of `login`.