### PR TITLE
fix: address the open bug issues

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -470,7 +470,15 @@ func openBrowser(url string) error {
 		return err
 	}
 
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// Reap the browser process; its exit status is of no interest to us, but
+	// without a Wait it lingers as a zombie for the lifetime of the CLI.
+	go func() { _ = cmd.Wait() }()
+
+	return nil
 }
 
 // browserCommand builds the command that opens url, honouring --browser-command.

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -73,7 +73,7 @@ type Stats struct {
 // Tracker maintains an in-memory registry of issued certs and server stats.
 // It subscribes to audit events and updates its state automatically.
 type Tracker struct {
-	mu sync.RWMutex
+	mu sync.Mutex
 
 	startedAt        time.Time
 	certs            []CertRecord
@@ -128,16 +128,7 @@ func (t *Tracker) ActiveCerts() []CertRecord {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	now := time.Now()
-
-	// Prune expired certs.
-	active := t.certs[:0]
-	for _, c := range t.certs {
-		if c.ExpiresAt.After(now) {
-			active = append(active, c)
-		}
-	}
-	t.certs = active
+	active := t.pruneExpiredLocked()
 
 	// Return a copy.
 	result := make([]CertRecord, len(active))
@@ -145,18 +136,31 @@ func (t *Tracker) ActiveCerts() []CertRecord {
 	return result
 }
 
-// GetStats returns the current server statistics.
-func (t *Tracker) GetStats() Stats {
-	activeCerts := t.ActiveCerts()
+// pruneExpiredLocked drops expired cert records and returns the remaining ones.
+// Callers must hold t.mu for writing.
+func (t *Tracker) pruneExpiredLocked() []CertRecord {
+	now := time.Now()
+	active := t.certs[:0]
+	for _, c := range t.certs {
+		if c.ExpiresAt.After(now) {
+			active = append(active, c)
+		}
+	}
+	t.certs = active
+	return active
+}
 
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+// GetStats returns the current server statistics. Everything is read under a
+// single lock so the counters and the cert count describe the same instant.
+func (t *Tracker) GetStats() Stats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	return Stats{
 		StartedAt:          t.startedAt,
 		Uptime:             time.Since(t.startedAt).Round(time.Second).String(),
 		TotalCertsIssued:   t.totalCertsIssued,
-		ActiveCerts:        len(activeCerts),
+		ActiveCerts:        len(t.pruneExpiredLocked()),
 		TotalAuthSuccesses: t.totalAuthSuccess,
 		TotalAuthFailures:  t.totalAuthFailure,
 		TotalCertErrors:    t.totalCertErrors,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -169,14 +169,14 @@ func Load(configPath string) (*ResolvedConfig, error) {
 
 	// Endpoints: env var (comma-separated) > file (list).
 	if envEndpoints := os.Getenv("TALOSCTL_OIDC_ENDPOINTS"); envEndpoints != "" {
-		rc.Endpoints = strings.Split(envEndpoints, ",")
+		rc.Endpoints = splitCSV(envEndpoints)
 	} else if len(fileCfg.Endpoints) > 0 {
 		rc.Endpoints = fileCfg.Endpoints
 	}
 
 	// Roles: env var (comma-separated) > file (list).
 	if envRoles := os.Getenv("TALOSCTL_OIDC_ROLES"); envRoles != "" {
-		rc.Roles = strings.Split(envRoles, ",")
+		rc.Roles = splitCSV(envRoles)
 	} else if len(fileCfg.Roles) > 0 {
 		rc.Roles = fileCfg.Roles
 	}
@@ -203,14 +203,14 @@ func Load(configPath string) (*ResolvedConfig, error) {
 
 	// IP allowlist: env var (comma-separated) > file.
 	if envAllowlist := os.Getenv("TALOSCTL_OIDC_IP_ALLOWLIST"); envAllowlist != "" {
-		rc.IPAllowlist = strings.Split(envAllowlist, ",")
+		rc.IPAllowlist = splitCSV(envAllowlist)
 	} else if len(fileCfg.IPAllowlist) > 0 {
 		rc.IPAllowlist = fileCfg.IPAllowlist
 	}
 
 	// Trusted proxies: env var (comma-separated) > file.
 	if envTrusted := os.Getenv("TALOSCTL_OIDC_TRUSTED_PROXIES"); envTrusted != "" {
-		rc.TrustedProxies = strings.Split(envTrusted, ",")
+		rc.TrustedProxies = splitCSV(envTrusted)
 	} else if len(fileCfg.TrustedProxies) > 0 {
 		rc.TrustedProxies = fileCfg.TrustedProxies
 	}
@@ -302,4 +302,16 @@ func envOrDefault(envKey, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// splitCSV splits a comma-separated env value, trimming spaces and dropping
+// empty entries so "a, ,b," yields ["a", "b"].
+func splitCSV(v string) []string {
+	var out []string
+	for _, p := range strings.Split(v, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -387,3 +387,19 @@ insecure: false
 		t.Error("Insecure should be true (env override), got false")
 	}
 }
+
+func TestSplitCSV(t *testing.T) {
+	got := splitCSV("a, b ,,c,")
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("splitCSV: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("splitCSV: got %v, want %v", got, want)
+		}
+	}
+	if splitCSV(" , ") != nil {
+		t.Fatalf("splitCSV: blank input should yield nil")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -275,13 +275,16 @@ func (s *Server) loadOrGenerateSelfSignedTLS() (*tls.Config, error) {
 		log.Printf("Loading persisted self-signed TLS certificates from %s", s.cfg.DataDir)
 		return tlsCfg, nil
 	}
-	if !os.IsNotExist(err) && !isPathError(err) {
+	if errors.Is(err, errCertExpired) {
+		log.Printf("Regenerating self-signed TLS certificates in %s: %v", s.cfg.DataDir, err)
+	} else if !os.IsNotExist(err) && !isPathError(err) {
 		// Unexpected error (not "file not found") — surface it.
 		return nil, fmt.Errorf("loading persisted TLS certificates: %w", err)
+	} else {
+		log.Printf("No persisted certificates found in %s, generating new ones", s.cfg.DataDir)
 	}
 
 	// Generate fresh certificates.
-	log.Printf("No persisted certificates found in %s, generating new ones", s.cfg.DataDir)
 	var caPEM, caKeyPEM, srvCertPEM, srvKeyPEM []byte
 	tlsCfg, caPEM, caKeyPEM, srvCertPEM, srvKeyPEM, err = s.generateSelfSignedMaterial()
 	if err != nil {
@@ -314,6 +317,14 @@ func (s *Server) loadOrGenerateSelfSignedTLS() (*tls.Config, error) {
 	return tlsCfg, nil
 }
 
+// selfSignedRenewBefore is how long before expiry persisted certificates are
+// considered stale and regenerated.
+const selfSignedRenewBefore = 24 * time.Hour
+
+// errCertExpired signals that persisted TLS material is past (or close to) its
+// expiry and must be regenerated rather than loaded.
+var errCertExpired = errors.New("persisted TLS certificate expired or expiring soon")
+
 // loadPersistedSelfSignedTLS loads previously saved self-signed TLS material.
 func (s *Server) loadPersistedSelfSignedTLS(caCrtPath, caKeyPath, srvCrtPath, srvKeyPath string) (*tls.Config, error) {
 	caPEM, err := os.ReadFile(caCrtPath)
@@ -333,6 +344,19 @@ func (s *Server) loadPersistedSelfSignedTLS(caCrtPath, caKeyPath, srvCrtPath, sr
 	tlsCert, err := tls.LoadX509KeyPair(srvCrtPath, srvKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading server key pair from %s / %s: %w", srvCrtPath, srvKeyPath, err)
+	}
+
+	leaf := tlsCert.Leaf
+	if leaf == nil {
+		leaf, err = x509.ParseCertificate(tlsCert.Certificate[0])
+		if err != nil {
+			return nil, fmt.Errorf("parsing persisted server certificate: %w", err)
+		}
+	}
+	// Renew a day early: a long-running server must never end up serving an
+	// expired certificate.
+	if time.Now().After(leaf.NotAfter.Add(-selfSignedRenewBefore)) {
+		return nil, fmt.Errorf("%w (server certificate expires %s)", errCertExpired, leaf.NotAfter.Format(time.RFC3339))
 	}
 
 	// Verify that the CA key can still be loaded (sanity check).
@@ -502,7 +526,9 @@ func (s *Server) handleCA(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/x-pem-file")
-	w.Write(s.selfSignedCAPEM)
+	if _, err := w.Write(s.selfSignedCAPEM); err != nil {
+		log.Printf("/ca: writing response: %v", err)
+	}
 }
 
 // handleExchange validates an OIDC token and returns an ephemeral client certificate.
@@ -650,23 +676,22 @@ func (s *Server) handleExchange(w http.ResponseWriter, r *http.Request) {
 		TTL:       int(s.cfg.CertTTL.Seconds()),
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	writeJSON(w, resp)
 
 	s.auditLog(audit.Event{
-		Type:          audit.EventCertIssued,
-		RequestID:     requestID,
-		EventCategory: "authentication",
-		EventOutcome:  "success",
-		EventAction:   "token-exchange",
-		Severity:      "INFO",
-		Subject:       tc.Subject,
-		Email:         tc.Email,
-		Issuer:        tc.Issuer,
-		ClientIP:      clientIP,
-		Roles:         roles,
-		CertTTL:       s.cfg.CertTTL.String(),
-		CertExpiry:    &certExpiry,
+		Type:            audit.EventCertIssued,
+		RequestID:       requestID,
+		EventCategory:   "authentication",
+		EventOutcome:    "success",
+		EventAction:     "token-exchange",
+		Severity:        "INFO",
+		Subject:         tc.Subject,
+		Email:           tc.Email,
+		Issuer:          tc.Issuer,
+		ClientIP:        clientIP,
+		Roles:           roles,
+		CertTTL:         s.cfg.CertTTL.String(),
+		CertExpiry:      &certExpiry,
 		CertFingerprint: fingerprint,
 	})
 
@@ -762,7 +787,18 @@ func (s *Server) validateToken(ctx context.Context, idToken string) (*tokenClaim
 func writeError(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(ErrorResponse{Error: msg})
+	if err := json.NewEncoder(w).Encode(ErrorResponse{Error: msg}); err != nil {
+		log.Printf("writing error response: %v", err)
+	}
+}
+
+// writeJSON encodes v as a JSON response body. A failed write (client gone,
+// broken pipe) is logged instead of silently dropped.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("writing JSON response: %v", err)
+	}
 }
 
 // auditLog emits an audit event if an audit logger is configured.
@@ -860,8 +896,7 @@ func (s *Server) handleAdminStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stats := s.cfg.AdminTracker.GetStats()
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(stats)
+	writeJSON(w, stats)
 }
 
 // handleAdminCerts returns the list of currently active (non-expired) issued certificates.
@@ -880,7 +915,5 @@ func (s *Server) handleAdminCerts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	certs := s.cfg.AdminTracker.ActiveCerts()
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(certs)
+	writeJSON(w, certs)
 }
-

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,9 +1,20 @@
 package server
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 // newTestServer builds a minimal Server suitable for exercising the plain
@@ -73,4 +84,71 @@ func TestHandleCAMethodGuard(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLoadPersistedSelfSignedTLSRegeneratesExpired checks that an expired
+// persisted certificate is replaced instead of served (issue #38).
+func TestLoadPersistedSelfSignedTLSRegeneratesExpired(t *testing.T) {
+	dir := t.TempDir()
+	srv := New(Config{ListenAddr: ":8080", DataDir: dir})
+
+	// First call populates the data directory with valid material.
+	if _, err := srv.loadOrGenerateSelfSignedTLS(); err != nil {
+		t.Fatalf("initial generation failed: %v", err)
+	}
+
+	// Overwrite the server key pair with an already-expired one.
+	srvCrtPath, srvKeyPath := writeExpiredKeyPair(t, dir)
+
+	if _, err := srv.loadPersistedSelfSignedTLS(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), srvCrtPath, srvKeyPath); !errors.Is(err, errCertExpired) {
+		t.Fatalf("expected errCertExpired, got %v", err)
+	}
+
+	tlsCfg, err := srv.loadOrGenerateSelfSignedTLS()
+	if err != nil {
+		t.Fatalf("regeneration failed: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(tlsCfg.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatalf("parsing regenerated certificate: %v", err)
+	}
+	if time.Now().After(leaf.NotAfter) {
+		t.Fatalf("regenerated certificate is already expired (NotAfter %s)", leaf.NotAfter)
+	}
+}
+
+// writeExpiredKeyPair writes an expired self-signed key pair to dir as
+// server.crt / server.key.
+func writeExpiredKeyPair(t *testing.T, dir string) (crtPath, keyPath string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "expired"},
+		NotBefore:    time.Now().Add(-48 * time.Hour),
+		NotAfter:     time.Now().Add(-1 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+
+	crtPath = filepath.Join(dir, "server.crt")
+	keyPath = filepath.Join(dir, "server.key")
+	if err := os.WriteFile(crtPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("writing certificate: %v", err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+
+	return crtPath, keyPath
 }

--- a/pkg/talosconfig/talosconfig.go
+++ b/pkg/talosconfig/talosconfig.go
@@ -134,69 +134,6 @@ func (c *Context) IsCertificateExpired(threshold time.Duration) bool {
 	return time.Now().Add(threshold).After(expiry)
 }
 
-// SetContext adds or updates a context in the talosconfig with the given certificates
-// and sets it as the current context.
-func SetContext(config *Config, name string, endpoints []string, caCertPath, clientCertPath, clientKeyPath string) error {
-	// Read certificate files.
-	caCert, err := readAndEncode(caCertPath, "CA certificate")
-	if err != nil {
-		return err
-	}
-
-	clientCert, err := readAndEncode(clientCertPath, "client certificate")
-	if err != nil {
-		return err
-	}
-
-	clientKey, err := readAndEncode(clientKeyPath, "client key")
-	if err != nil {
-		return err
-	}
-
-	ctx := &Context{
-		Endpoints: endpoints,
-		CA:        caCert,
-		Crt:       clientCert,
-		Key:       clientKey,
-	}
-
-	config.Contexts[name] = ctx
-	config.Context = name
-
-	return nil
-}
-
-// readAndEncode reads a file and returns its content as base64.
-// It handles three formats:
-//   - PEM (-----BEGIN ...) → base64-encode as-is
-//   - Already base64-encoded PEM → use as-is (decoded content starts with -----BEGIN)
-//   - Other → error
-func readAndEncode(path string, label string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", label, err)
-	}
-
-	content := bytes.TrimSpace(data)
-	if len(content) == 0 {
-		return "", fmt.Errorf("%s file is empty: %s", label, path)
-	}
-
-	// Case 1: File contains PEM directly.
-	if bytes.HasPrefix(content, []byte("-----BEGIN ")) {
-		return base64.StdEncoding.EncodeToString(content), nil
-	}
-
-	// Case 2: File contains base64-encoded PEM (e.g. extracted from a talosconfig).
-	decoded, err := base64.StdEncoding.DecodeString(string(content))
-	if err == nil && bytes.HasPrefix(bytes.TrimSpace(decoded), []byte("-----BEGIN ")) {
-		// Already valid base64-encoded PEM, use as-is.
-		return string(content), nil
-	}
-
-	return "", fmt.Errorf("%s file is not a valid PEM or base64-encoded PEM: %s (file is %d bytes)", label, path, len(content))
-}
-
 // SetContextFromPEM adds or updates a context using raw PEM bytes (not file paths).
 // This is used when receiving certificates from the cert exchange server.
 func SetContextFromPEM(config *Config, name string, endpoints []string, caPEM, certPEM, keyPEM []byte) error {


### PR DESCRIPTION
Goes through the open bug issues and fixes the ones still valid. One commit per issue.

- `#46` / `#43` — `/ca` and the JSON handlers dropped write errors, they are logged now (via a small `writeJSON` helper)
- `#38` — persisted self-signed certs were reloaded even when expired, they are regenerated a day before expiry
- `#36` — `GetStats` took two locks in a row, it takes one now so the counters and the cert count match
- `#35` — the browser process was started without a `Wait`, it is reaped in a goroutine now
- `#39` — comma-separated env values are trimmed and empty entries dropped
- `#42` — removed the unused file-path `SetContext` variant

Tests added for the expiry check and the CSV parsing.

Note: `#32` (CA key PKCS#8 only) is stale — `pkg/certsign` no longer exists and nothing in the tree parses a CA private key anymore. Can be closed.